### PR TITLE
Correct image references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Elucidate is a Windows GUI front-end for the command-line SnapRAID application.
 
 ![Starting View](./Images/starting_view.png)
 
-![Settings Form](./Images/Settings_Form.png)
+![Settings Form](./Images/Settings_Form.PNG)
 
 
 ## Can you Help ? 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -15,49 +15,49 @@
 ----
 
 ### Elucidate user settings
-![](../images/Settings_ErrorProviders.png) 
+![](../Images/Settings_ErrorProviders.png) 
 The application attempts to help you by using the flashing error icons. These also have a tool-tip on them giving a brief hint as to what the problem may be.
 The settings that are stored are on a per user basis, so the settings can be made common or specific to each logged on users requirements.
 _Each area of the window does have tool-tips as a brief reminder of their function._
 
 #### SnapRAID Application location
-![](../images/Settings_SnapRaid Exe.png) 
+![](../Images/Settings_SnapRaid%20Exe.png) 
 This is required by the GUI application in order to be able to drive it with the commands that you require. It needs to be visible to this current user of this GUI. The Error icon will exist if this application cannot be found.
 
 #### SnapRAID config file location
-![](../images/Settings_SnapRaid Config.png)
+![](../Images/Settings_SnapRaid%20Config.png)
 This is required by the SnapRAID application in order to be able to drive it with the commands that you require. It needs to be visible to this current user of this GUI. The Error icon will exist if this application cannot be found.
 
 #### "Use verbose"
-![](../images/Settings_UseVerbose.png)
+![](../Images/Settings_UseVerbose.png)
 This makes the output from SnapRAID go into verbose mode. All this information is placed into the log file for viewing later.
 
 #### "Reset to last config"
-![](../images/Settings_ResetToLast.png)
+![](../Images/Settings_ResetToLast.png)
 Pressing this button will revert the settings in this window back to the last saved configuration. This is especially useful if you feel you have made a mistake with the order of the protection sources
 
 #### "Save Settings"
-![](../images/Settings_SaveSettings.png)
+![](../Images/Settings_SaveSettings.png)
 Any changes that have occurred in this window, will cause an Error icon to appear next to this button. It is a reminder that those changes will not be used. If the settings do not pass a certain number of internal validation tests, then the Main application will not enable any of it's buttons.
 
 ### Snapraid Config File
 Parameters affecting the Snapraid Config
 
 #### Possible source Locations
-![](../images/Settings_Sources.png)
+![](../Images/Settings_Sources.png)
 This area shows the current visible items that SnapRAID will be able to protect. To move them over to the protection list you can either double click, or drag and drop. The Drop location will also be the order in which they will be used. Subdirectories can be protected by just expanding the tree and then dragging them.
 **It is important that you do not choose the parity location**
 
 #### Snapshot Sources
-![](../images/Settings_Snap%20Sources.png) 
+![](../Images/Settings_Snap%20Sources.png) 
 This area shows the currently protected locations. Do not change the order of these once a SnapRAID has been created. The initial order can be changed by dragging and dropping within this area. To remove a location - _before_ protection has been created - just select it and press delete.
 
 #### Parity Locations
-![](../images/Settings_ParityFileLocs.png)
+![](../Images/Settings_ParityFileLocs.png)
 SnapRAID has 2 types of snapshot protection, These are _similar_ to Raid 5 and Raid 6, in that 5 protects a single source being removed / corrupted, and Raid 6 protects against 2. These location need to be on different media, and need to be on a disk that can accept large files (i.e. not FAT). The space available @ these locations needs to greater than the largest are that needs to be protected.
 
 #### Filter Exclusions
-![](../images/Settings_ExcludedPatterns.png) 
+![](../Images/Settings_ExcludedPatterns.png) 
 * SnapRAID currently (1.4 onwards) 
 	* Ignores in sync System and Hidden files in Windows
 	* Files without read permission are ignored in sync.


### PR DESCRIPTION
Images not displaying online (nor in unix fork) as image != Image 😄