### PR TITLE
- LogView Performance -> Remove half in bulk

### DIFF
--- a/Elucidate/Elucidate/Controls/ListBoxLog.cs
+++ b/Elucidate/Elucidate/Controls/ListBoxLog.cs
@@ -2,300 +2,301 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Drawing;
+using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 // ReSharper disable MemberCanBePrivate.Global
 
 // ReSharper disable UnusedMember.Global
 
-namespace Elucidate.Controls
+namespace Elucidate.Controls;
+
+/// <summary>
+/// Stolen from
+/// https://stackoverflow.com/questions/2196097/elegant-log-window-in-winforms-c-sharp
+/// and then
+/// - reformatted to make it work with NLog style levels
+/// - Made to work for multi-line
+/// - Updates via a timer
+/// </summary>
+public sealed class ListBoxLog : IDisposable
 {
-    /// <summary>
-    /// Stolen from
-    /// https://stackoverflow.com/questions/2196097/elegant-log-window-in-winforms-c-sharp
-    /// and then
-    /// - reformatted to make it work with NLog style levels
-    /// - Made to work for multi-line
-    /// - Updates via a timer
-    /// </summary>
-    public sealed class ListBoxLog : IDisposable
+    private const int DEFAULT_MAX_LINES_IN_LISTBOX = 2000;
+    private const int DEFAULT_UPDATE_FREQUENCY_MS = 250;
+
+    private bool disposed;
+    private ListBox listBoxInt;
+    private readonly int maxEntriesInListBox;
+    private readonly Timer timer1;
+
+    private class LogString
     {
-        private const int DEFAULT_MAX_LINES_IN_LISTBOX = 2000;
-        private const int DEFAULT_UPDATE_FREQUENCY_MS = 250;
+        public string LevelUppercase;
+        public string Message;
+    };
 
-        private bool disposed;
-        private ListBox listBoxInt;
-        private readonly int maxEntriesInListBox;
-        private readonly Timer timer1;
+    private readonly ConcurrentQueue<LogString> pendingLogMessages = new();
+    private bool alreadyDequeing;
 
-        private class LogString
+    public ListBoxLog(ListBox listBox, int maxLinesInListbox = DEFAULT_MAX_LINES_IN_LISTBOX, int defaultUpdateFrequencyms = DEFAULT_UPDATE_FREQUENCY_MS)
+    {
+        disposed = false;
+
+        listBoxInt = listBox;
+        maxEntriesInListBox = maxLinesInListbox;
+
+        Paused = false;
+
+        listBoxInt.SelectionMode = SelectionMode.MultiExtended;
+        // Display a horizontal scroll bar.
+        listBoxInt.HorizontalScrollbar = true;
+        listBoxInt.DrawMode = DrawMode.OwnerDrawVariable;
+
+        listBoxInt.HandleCreated += OnHandleCreated;
+        listBoxInt.HandleDestroyed += OnHandleDestroyed;
+        listBoxInt.DrawItem += DrawItemHandler;
+        listBoxInt.KeyDown += KeyDownHandler;
+        listBoxInt.MeasureItem += MeasureItem;
+
+        var menuItems = new[] { new MenuItem("Copy", CopyMenuOnClickHandler) };
+        listBoxInt.ContextMenu = new ContextMenu(menuItems);
+        listBoxInt.ContextMenu.Popup += CopyMenuPopupHandler;
+
+        timer1 = new Timer
         {
-            public string LevelUppercase;
-            public string Message;
+            Enabled = listBox.IsHandleCreated,
+            Interval = defaultUpdateFrequencyms,
         };
+        timer1.Tick += timer1_Tick;
 
-        private readonly ConcurrentQueue<LogString> pendingLogMessages = new ();
-        private bool alreadyDequing;
+    }
 
-        public ListBoxLog(ListBox listBox, int maxLinesInListbox = DEFAULT_MAX_LINES_IN_LISTBOX, int defaultUpdateFrequencyms = DEFAULT_UPDATE_FREQUENCY_MS)
+    public void LogMethod(string levelUppercase, string message)
+    {
+        pendingLogMessages.Enqueue(new LogString
         {
-            disposed = false;
+            LevelUppercase = levelUppercase,
+            Message = message
+        });
+    }
 
-            listBoxInt = listBox;
-            maxEntriesInListBox = maxLinesInListbox;
 
-            Paused = false;
+    public bool Paused { get; set; }
 
-            listBoxInt.SelectionMode = SelectionMode.MultiExtended;
-            // Display a horizontal scroll bar.
-            listBoxInt.HorizontalScrollbar = true;
-            listBoxInt.DrawMode = DrawMode.OwnerDrawVariable;
-
-            listBoxInt.HandleCreated += OnHandleCreated;
-            listBoxInt.HandleDestroyed += OnHandleDestroyed;
-            listBoxInt.DrawItem += DrawItemHandler;
-            listBoxInt.KeyDown += KeyDownHandler;
-            listBoxInt.MeasureItem += MeasureItem;
-
-            var menuItems = new[] { new MenuItem("Copy", CopyMenuOnClickHandler) };
-            listBoxInt.ContextMenu = new ContextMenu(menuItems);
-            listBoxInt.ContextMenu.Popup += CopyMenuPopupHandler;
-
-            timer1 = new Timer
-            {
-                Enabled = listBox.IsHandleCreated,
-                Interval = defaultUpdateFrequencyms,
-            };
-            timer1.Tick += timer1_Tick;
-
+    ~ListBoxLog()
+    {
+        if (!disposed)
+        {
+            Dispose(false);
+            disposed = true;
         }
+    }
 
-        public void LogMethod(string levelUppercase, string message)
+    public void Dispose()
+    {
+        if (!disposed)
         {
-            pendingLogMessages.Enqueue(new LogString
+            Dispose(true);
+            GC.SuppressFinalize(this);
+            disposed = true;
+        }
+    }
+
+    private void OnHandleCreated(object sender, EventArgs e)
+    {
+        timer1.Enabled = true;
+    }
+
+    private void OnHandleDestroyed(object sender, EventArgs e)
+    {
+        timer1.Enabled = false;
+    }
+
+    private void MeasureItem(object sender, MeasureItemEventArgs e)
+    {
+        if (e.Index >= 0)
+        {
+            if (((ListBox)sender).Items[e.Index] is not LogString logEvent)
             {
-                LevelUppercase = levelUppercase,
-                Message = message
+                logEvent = new LogString
+                {
+                    LevelUppercase = @"FATAL",
+                    Message = ((ListBox)sender).Items[e.Index].ToString()
+                };
+            }
+
+            Size sizeF = TextRenderer.MeasureText(e.Graphics, logEvent.Message, listBoxInt.Font);
+
+            e.ItemHeight = sizeF.Height + 2;
+            if (listBoxInt.HorizontalExtent < sizeF.Width)
+            {
+                listBoxInt.HorizontalExtent = sizeF.Width + 2;
+            }
+        }
+    }
+
+
+    private void DrawItemHandler(object sender, DrawItemEventArgs e)
+    {
+        if (e.Index >= 0)
+        {
+            e.DrawBackground();
+            e.DrawFocusRectangle();
+
+            // SafeGuard against wrong configuration of list box
+            if (((ListBox)sender).Items[e.Index] is not LogString logEvent)
+            {
+                logEvent = new LogString
+                {
+                    LevelUppercase = @"FATAL",
+                    Message = ((ListBox)sender).Items[e.Index].ToString()
+                };
+            }
+
+            Color color = logEvent.LevelUppercase switch
+            {
+                @"FATAL" => Color.White,
+                @"ERROR" => Color.Red,
+                @"WARN" => Color.Goldenrod,
+                @"INFO" => Color.Black,
+                @"DEBUG" => Color.Gray,
+                @"TRACE" => Color.DarkGray,
+                _ => Color.Black
+            };
+
+            if (logEvent.LevelUppercase == @"FATAL")
+            {
+                e.Graphics.FillRectangle(Brushes.Red, e.Bounds);
+            }
+            // https://blogs.msdn.microsoft.com/cjacks/2006/05/19/gdi-vs-gdi-text-rendering-performance/
+            TextRenderer.DrawText(e.Graphics, logEvent.Message, listBoxInt.Font, new Point(0, e.Bounds.Y + 2), color, TextFormatFlags.ExternalLeading);
+        }
+    }
+
+    private void KeyDownHandler(object sender, KeyEventArgs e)
+    {
+        if (e.Modifiers == Keys.Control)
+        {
+            if (e.KeyCode == Keys.C)
+            {
+                CopyToClipboard();
+            }
+            else if (e.KeyCode == Keys.C)
+            {
+                listBoxInt.BeginUpdate();
+                for (var i = listBoxInt.Items.Count - 1; i >= 0; i--)
+                {
+                    listBoxInt.SetSelected(i, true);
+                }
+                listBoxInt.EndUpdate();
+            }
+        }
+    }
+
+    private void CopyMenuOnClickHandler(object sender, EventArgs e)
+    {
+        CopyToClipboard();
+    }
+
+    private void CopyMenuPopupHandler(object sender, EventArgs e)
+    {
+        if (sender is ContextMenu menu)
+        {
+            menu.MenuItems[0].Enabled = (listBoxInt.SelectedItems.Count > 0);
+        }
+    }
+
+    private void timer1_Tick(object sender, EventArgs e)
+    {
+        try
+        {
+            if (alreadyDequeing
+                || pendingLogMessages.IsEmpty)
+            {
+                return;
+            }
+
+            // Now lock in case the timer is overlapping !
+            alreadyDequeing = true;
+
+            listBoxInt.BeginInvoke((MethodInvoker)delegate
+            {
+                //some stuffs for best performance
+                listBoxInt.BeginUpdate();
+
+                if (listBoxInt.Items.Count > maxEntriesInListBox)
+                {
+                    var existingLogs = new object[listBoxInt.Items.Count];
+                    listBoxInt.Items.CopyTo(existingLogs, 0);
+                    listBoxInt.Items.Clear();
+                    listBoxInt.Items.AddRange(existingLogs.Skip(maxEntriesInListBox / 2).ToArray());
+                }
+
+                // find the style to use
+                while (pendingLogMessages.TryDequeue(out LogString log))
+                {
+                    listBoxInt.Items.Add(log);
+                }
+
+                if (!Paused)
+                {
+                    listBoxInt.TopIndex = listBoxInt.Items.Count - 1;
+                }
+
+                listBoxInt.EndUpdate();
+                alreadyDequeing = false;
             });
         }
-
-
-        public bool Paused { get; set; }
-
-        ~ListBoxLog()
+        catch (Exception ex)
         {
-            if (!disposed)
+            Debug.Fail(ex.Message);
+        }
+    }
+
+    private void CopyToClipboard()
+    {
+        if (listBoxInt.SelectedItems.Count > 0)
+        {
+            var selectedItemsAsRtfText = new StringBuilder();
+            //selectedItemsAsRtfText.AppendLine(@"{\rtf1\ansi\deff0{\fonttbl{\f0\fcharset0 Courier;}}");
+            //selectedItemsAsRtfText.AppendLine(
+            //    @"{\colortbl;\red255\green255\blue255;\red255\green0\blue0;\red218\green165\blue32;\red0\green128\blue0;\red0\green0\blue255;\red0\green0\blue0}");
+            foreach (LogString logEvent in listBoxInt.SelectedItems)
             {
-                Dispose(false);
-                disposed = true;
+                //selectedItemsAsRtfText.AppendFormat(@"{{\f0\fs16\chshdng0\chcbpat{0}\cb{0}\cf{1} ",
+                //    (logEvent.LevelUppercase == @"FATAL") ? 2 : 1,
+                //    (logEvent.LevelUppercase == @"FATAL") ? 1 :
+                //    ((int)logEvent.Level > 5) ? 6 : ((int)logEvent.Level) + 1);
+                //selectedItemsAsRtfText.Append(FormatALogEventMessage(logEvent, messageFormat));
+                //selectedItemsAsRtfText.AppendLine(@"\par}");
+                selectedItemsAsRtfText.AppendLine(logEvent.Message);
             }
-        }
 
-        public void Dispose()
-        {
-            if (!disposed)
-            {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-                disposed = true;
-            }
+            //selectedItemsAsRtfText.AppendLine(@"}");
+            //Clipboard.SetData(DataFormats.Rtf, selectedItemsAsRtfText.ToString());
+            Clipboard.SetData(DataFormats.UnicodeText, selectedItemsAsRtfText.ToString());
         }
+    }
 
-        private void OnHandleCreated(object sender, EventArgs e)
-        {
-            timer1.Enabled = true;
-        }
 
-        private void OnHandleDestroyed(object sender, EventArgs e)
+    private void Dispose(bool _)
+    {
+        if (listBoxInt != null)
         {
             timer1.Enabled = false;
-        }
 
-        private void MeasureItem(object sender, MeasureItemEventArgs e)
-        {
-            if (e.Index >= 0)
-            {
-                if (((ListBox)sender).Items[e.Index] is not LogString logEvent)
-                {
-                    logEvent = new LogString
-                    {
-                        LevelUppercase = @"FATAL",
-                        Message = ((ListBox)sender).Items[e.Index].ToString()
-                    };
-                }
+            listBoxInt.HandleCreated -= OnHandleCreated;
+            listBoxInt.HandleCreated -= OnHandleDestroyed;
+            listBoxInt.DrawItem -= DrawItemHandler;
+            listBoxInt.KeyDown -= KeyDownHandler;
 
-                Size sizeF = TextRenderer.MeasureText(e.Graphics, logEvent.Message, listBoxInt.Font);
+            listBoxInt.ContextMenu.MenuItems.Clear();
+            listBoxInt.ContextMenu.Popup -= CopyMenuPopupHandler;
+            listBoxInt.ContextMenu = null;
 
-                e.ItemHeight = sizeF.Height + 2;
-                if (listBoxInt.HorizontalExtent < sizeF.Width)
-                {
-                    listBoxInt.HorizontalExtent = sizeF.Width + 2;
-                }
-            }
-        }
-
-
-        private void DrawItemHandler(object sender, DrawItemEventArgs e)
-        {
-            if (e.Index >= 0)
-            {
-                e.DrawBackground();
-                e.DrawFocusRectangle();
-
-                // SafeGuard against wrong configuration of list box
-                if (((ListBox)sender).Items[e.Index] is not LogString logEvent)
-                {
-                    logEvent = new LogString
-                    {
-                        LevelUppercase = @"FATAL",
-                        Message = ((ListBox)sender).Items[e.Index].ToString()
-                    };
-                }
-
-                Color color = logEvent.LevelUppercase switch
-                              {
-                                  @"FATAL" => Color.White,
-                                  @"ERROR" => Color.Red,
-                                  @"WARN"  => Color.Goldenrod,
-                                  @"INFO"  => Color.Black,
-                                  @"DEBUG" => Color.Gray,
-                                  @"TRACE" => Color.DarkGray,
-                                  _        => Color.Black
-                              };
-
-                if (logEvent.LevelUppercase == @"FATAL")
-                {
-                    e.Graphics.FillRectangle(Brushes.Red, e.Bounds);
-                }
-                // https://blogs.msdn.microsoft.com/cjacks/2006/05/19/gdi-vs-gdi-text-rendering-performance/
-                TextRenderer.DrawText(e.Graphics, logEvent.Message, listBoxInt.Font, new Point(0, e.Bounds.Y + 2), color, TextFormatFlags.ExternalLeading);
-            }
-        }
-
-        private void KeyDownHandler(object sender, KeyEventArgs e)
-        {
-            if (e.Modifiers == Keys.Control)
-            {
-                if (e.KeyCode == Keys.C)
-                {
-                    CopyToClipboard();
-                }
-                else if (e.KeyCode == Keys.C)
-                {
-                    listBoxInt.BeginUpdate();
-                    for (var i = listBoxInt.Items.Count - 1; i >= 0; i--)
-                    {
-                        listBoxInt.SetSelected(i, true);
-                    }
-                    listBoxInt.EndUpdate();
-                }
-            }
-        }
-
-        private void CopyMenuOnClickHandler(object sender, EventArgs e)
-        {
-            CopyToClipboard();
-        }
-
-        private void CopyMenuPopupHandler(object sender, EventArgs e)
-        {
-            if (sender is ContextMenu menu)
-            {
-                menu.MenuItems[0].Enabled = (listBoxInt.SelectedItems.Count > 0);
-            }
-        }
-
-        private void timer1_Tick(object sender, EventArgs e)
-        {
-            try
-            {
-                if (alreadyDequing
-                || pendingLogMessages.IsEmpty)
-                {
-                    return;
-                }
-
-                // Now lock in case the timer is overlapping !
-                alreadyDequing = true;
-
-                listBoxInt.BeginInvoke((MethodInvoker)delegate
-               {
-                   //some stuffs for best performance
-                   listBoxInt.BeginUpdate();
-
-                   // find the style to use
-                   while (pendingLogMessages.TryDequeue(out LogString log))
-                   {
-                       listBoxInt.Items.Add(log);
-                   }
-
-                   if (listBoxInt.Items.Count > maxEntriesInListBox)
-                   {
-                       listBoxInt.Items.RemoveAt(0);
-                   }
-
-                   if (!Paused)
-                   {
-                       listBoxInt.TopIndex = listBoxInt.Items.Count - 1;
-                   }
-
-                   listBoxInt.EndUpdate();
-                   alreadyDequing = false;
-               }
-                );
-            }
-            catch (Exception ex)
-            {
-                Debug.Fail(ex.Message);
-            }
-        }
-
-        private void CopyToClipboard()
-        {
-            if (listBoxInt.SelectedItems.Count > 0)
-            {
-                var selectedItemsAsRtfText = new StringBuilder();
-                //selectedItemsAsRtfText.AppendLine(@"{\rtf1\ansi\deff0{\fonttbl{\f0\fcharset0 Courier;}}");
-                //selectedItemsAsRtfText.AppendLine(
-                //    @"{\colortbl;\red255\green255\blue255;\red255\green0\blue0;\red218\green165\blue32;\red0\green128\blue0;\red0\green0\blue255;\red0\green0\blue0}");
-                foreach (LogString logEvent in listBoxInt.SelectedItems)
-                {
-                    //selectedItemsAsRtfText.AppendFormat(@"{{\f0\fs16\chshdng0\chcbpat{0}\cb{0}\cf{1} ",
-                    //    (logEvent.LevelUppercase == @"FATAL") ? 2 : 1,
-                    //    (logEvent.LevelUppercase == @"FATAL") ? 1 :
-                    //    ((int)logEvent.Level > 5) ? 6 : ((int)logEvent.Level) + 1);
-                    //selectedItemsAsRtfText.Append(FormatALogEventMessage(logEvent, messageFormat));
-                    //selectedItemsAsRtfText.AppendLine(@"\par}");
-                    selectedItemsAsRtfText.AppendLine(logEvent.Message);
-                }
-
-                //selectedItemsAsRtfText.AppendLine(@"}");
-                //Clipboard.SetData(DataFormats.Rtf, selectedItemsAsRtfText.ToString());
-                Clipboard.SetData(DataFormats.UnicodeText, selectedItemsAsRtfText.ToString());
-            }
-
-        }
-
-
-        private void Dispose(bool _)
-        {
-            if (listBoxInt != null)
-            {
-                timer1.Enabled = false;
-
-                listBoxInt.HandleCreated -= OnHandleCreated;
-                listBoxInt.HandleCreated -= OnHandleDestroyed;
-                listBoxInt.DrawItem -= DrawItemHandler;
-                listBoxInt.KeyDown -= KeyDownHandler;
-
-                listBoxInt.ContextMenu.MenuItems.Clear();
-                listBoxInt.ContextMenu.Popup -= CopyMenuPopupHandler;
-                listBoxInt.ContextMenu = null;
-
-                listBoxInt.Items.Clear();
-                listBoxInt.DrawMode = DrawMode.Normal;
-                listBoxInt = null;
-            }
+            listBoxInt.Items.Clear();
+            listBoxInt.DrawMode = DrawMode.Normal;
+            listBoxInt = null;
         }
     }
 }

--- a/Elucidate/Elucidate/Controls/ProtectedDrivesDisplay.Designer.cs
+++ b/Elucidate/Elucidate/Controls/ProtectedDrivesDisplay.Designer.cs
@@ -45,7 +45,7 @@
             this.kryptonPanel1.Controls.Add(this.driveGrid);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPanel1.Name = "kryptonPanel1";
             this.kryptonPanel1.Size = new System.Drawing.Size(537, 357);
             this.kryptonPanel1.TabIndex = 0;
@@ -56,6 +56,7 @@
             this.driveGrid.AllowUserToResizeColumns = false;
             this.driveGrid.AllowUserToResizeRows = false;
             this.driveGrid.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
+            this.driveGrid.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.driveGrid.ColumnHeadersHeight = 36;
             this.driveGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.colPath,
@@ -65,7 +66,7 @@
             this.driveGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.driveGrid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
             this.driveGrid.Location = new System.Drawing.Point(0, 0);
-            this.driveGrid.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.driveGrid.Margin = new System.Windows.Forms.Padding(4);
             this.driveGrid.MultiSelect = false;
             this.driveGrid.Name = "driveGrid";
             this.driveGrid.RowHeadersVisible = false;
@@ -73,6 +74,9 @@
             this.driveGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.driveGrid.ShowEditingIcon = false;
             this.driveGrid.Size = new System.Drawing.Size(537, 357);
+            this.driveGrid.StateCommon.BackStyle = Krypton.Toolkit.PaletteBackStyle.GridBackgroundList;
+            this.driveGrid.StateCommon.HeaderColumn.Content.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.driveGrid.StateCommon.HeaderColumn.Content.Hint = Krypton.Toolkit.PaletteTextHint.AntiAlias;
             this.driveGrid.TabIndex = 0;
             this.driveGrid.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.driveGrid_RowsAdded);
             this.driveGrid.MouseDown += new System.Windows.Forms.MouseEventHandler(this.DriveGrid_MouseDown);
@@ -85,7 +89,7 @@
             this.colPath.MinimumWidth = 6;
             this.colPath.Name = "colPath";
             this.colPath.ReadOnly = true;
-            this.colPath.Width = 70;
+            this.colPath.Width = 75;
             // 
             // colName
             // 
@@ -93,7 +97,7 @@
             this.colName.HeaderText = "Name";
             this.colName.MinimumWidth = 6;
             this.colName.Name = "colName";
-            this.colName.Width = 82;
+            this.colName.Width = 84;
             // 
             // colDriveSpace
             // 
@@ -107,7 +111,7 @@
             this.colDetails.HeaderText = "Prot : Used : Max";
             this.colDetails.MinimumWidth = 6;
             this.colDetails.Name = "colDetails";
-            this.colDetails.Width = 152;
+            this.colDetails.Width = 167;
             // 
             // ProtectedDrivesDisplay
             // 
@@ -115,7 +119,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.kryptonPanel1);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "ProtectedDrivesDisplay";
             this.Size = new System.Drawing.Size(537, 357);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();

--- a/Elucidate/Elucidate/Controls/ProtectedDrivesDisplay.cs
+++ b/Elucidate/Elucidate/Controls/ProtectedDrivesDisplay.cs
@@ -132,12 +132,13 @@ internal partial class ProtectedDrivesDisplay : UserControl
         {
             var dirInfo = new DirectoryInfo(coveragePath.DirectoryPath, PathFormat.FullPath);
             var driveInfo = new DriveInfo(dirInfo.Root.FullName);
-            if (coveragePath.PathType == PathTypeEnum.Parity)
+            if (coveragePath.PathType == PathTypeEnum.Parity
+                || dirInfo.FullName == driveInfo.Name)
             {
                 var totalUsed = driveInfo.TotalSize - driveInfo.AvailableFreeSpace;
-                var protectedUse = File.Exists(coveragePath.FullPath) ? new FileInfo(coveragePath.FullPath).Length : 0L;
+                var protectedUse = File.Exists(coveragePath.FullPath) ? new FileInfo(coveragePath.FullPath).Length : (dirInfo.FullName == driveInfo.Name)? totalUsed:0L;
                 row.Cells[2].Value = $@"{protectedUse}:{totalUsed}:{driveInfo.TotalSize}";
-                row.Cells[3].Value = $@"{new ByteSize(protectedUse)} : {new ByteSize(totalUsed)} : {new ByteSize(driveInfo.TotalSize)}";
+                row.Cells[3].Value = $@"{ByteSize.FromBytes(protectedUse).ToBinaryString()}  :  {ByteSize.FromBytes(totalUsed).ToBinaryString()}  :  {ByteSize.FromBytes(driveInfo.TotalSize).ToBinaryString()}";
             }
             else
             {
@@ -162,7 +163,7 @@ internal partial class ProtectedDrivesDisplay : UserControl
                {
                    row.Cells[2].Value = $@"{protectedUse}:{totalUsed}:{driveInfo.TotalSize}";
                    row.Cells[3].Value =
-                       $@"{new ByteSize(protectedUse)} : {new ByteSize(totalUsed)} : {new ByteSize(driveInfo.TotalSize)}";
+                       $@"{ByteSize.FromBytes(protectedUse).ToBinaryString()}  :  {ByteSize.FromBytes(totalUsed).ToBinaryString()}  :  {ByteSize.FromBytes(driveInfo.TotalSize).ToBinaryString()}";
                }
                catch
                {
@@ -185,7 +186,9 @@ internal partial class ProtectedDrivesDisplay : UserControl
     {
         try
         {
-            if (token.IsCancellationRequested)
+            if (token.IsCancellationRequested
+                || dir.EntryInfo.IsMountPoint
+                || dir.EntryInfo.IsSymbolicLink)
             {
                 return 0UL;
             }

--- a/Elucidate/Elucidate/Controls/RunControl.Designer.cs
+++ b/Elucidate/Elucidate/Controls/RunControl.Designer.cs
@@ -33,6 +33,7 @@ namespace Elucidate.Controls
             this.components = new System.ComponentModel.Container();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.tsStartTime = new Krypton.Toolkit.KryptonLabel();
+            this.toolStripProgressBar1 = new Elucidate.Shared.TextOverProgressBar();
             this.runWithoutCaptureMenuItem = new Krypton.Toolkit.KryptonCheckBox();
             this.checkBoxDisplayOutput = new Krypton.Toolkit.KryptonCheckBox();
             this.comboBoxProcessStatus = new Krypton.Toolkit.KryptonComboBox();
@@ -41,7 +42,6 @@ namespace Elucidate.Controls
             this.checkBoxCommandLineOptions = new Krypton.Toolkit.KryptonCheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
-            this.toolStripProgressBar1 = new Elucidate.Shared.TextOverProgressBar();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.comboBoxProcessStatus)).BeginInit();
             this.tableLayoutPanelAdditionalCommands.SuspendLayout();
@@ -82,18 +82,34 @@ namespace Elucidate.Controls
             this.tsStartTime.Margin = new System.Windows.Forms.Padding(0, 4, 0, 0);
             this.tsStartTime.MinimumSize = new System.Drawing.Size(170, 22);
             this.tsStartTime.Name = "tsStartTime";
-            this.tsStartTime.Size = new System.Drawing.Size(201, 31);
-            this.tsStartTime.StateCommon.ShortText.Font = new System.Drawing.Font("Tahoma", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tsStartTime.Size = new System.Drawing.Size(192, 31);
+            this.tsStartTime.StateCommon.ShortText.Font = new System.Drawing.Font("Tahoma", 10.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.tsStartTime.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
-            this.tsStartTime.StateCommon.ShortText.TextV = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.tsStartTime.StateCommon.ShortText.TextV = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.tsStartTime.TabIndex = 0;
             this.tsStartTime.TabStop = false;
             this.tsStartTime.Values.Text = "2000-01-01 00:00:00Z";
             // 
+            // toolStripProgressBar1
+            // 
+            this.toolStripProgressBar1.ContainerControl = this;
+            this.toolStripProgressBar1.DisplayText = "";
+            this.toolStripProgressBar1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.toolStripProgressBar1.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.toolStripProgressBar1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(50)))), ((int)(((byte)(205)))), ((int)(((byte)(50)))));
+            this.toolStripProgressBar1.Location = new System.Drawing.Point(708, 3);
+            this.toolStripProgressBar1.Margin = new System.Windows.Forms.Padding(0);
+            this.toolStripProgressBar1.Name = "toolStripProgressBar1";
+            this.toolStripProgressBar1.ShowInTaskbar = true;
+            this.toolStripProgressBar1.Size = new System.Drawing.Size(382, 35);
+            this.toolStripProgressBar1.Step = 3;
+            this.toolStripProgressBar1.TabIndex = 4;
+            this.toolStripProgressBar1.TextColor = System.Drawing.SystemColors.ControlText;
+            // 
             // runWithoutCaptureMenuItem
             // 
             this.runWithoutCaptureMenuItem.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.runWithoutCaptureMenuItem.Location = new System.Drawing.Point(508, 3);
+            this.runWithoutCaptureMenuItem.Location = new System.Drawing.Point(499, 3);
             this.runWithoutCaptureMenuItem.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.runWithoutCaptureMenuItem.MinimumSize = new System.Drawing.Size(122, 22);
             this.runWithoutCaptureMenuItem.Name = "runWithoutCaptureMenuItem";
@@ -108,7 +124,7 @@ namespace Elucidate.Controls
             this.checkBoxDisplayOutput.Checked = true;
             this.checkBoxDisplayOutput.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxDisplayOutput.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.checkBoxDisplayOutput.Location = new System.Drawing.Point(342, 3);
+            this.checkBoxDisplayOutput.Location = new System.Drawing.Point(333, 3);
             this.checkBoxDisplayOutput.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.checkBoxDisplayOutput.MinimumSize = new System.Drawing.Size(86, 22);
             this.checkBoxDisplayOutput.Name = "checkBoxDisplayOutput";
@@ -133,11 +149,11 @@ namespace Elucidate.Controls
             "Idle",
             "Pause",
             "Abort"});
-            this.comboBoxProcessStatus.Location = new System.Drawing.Point(211, 6);
+            this.comboBoxProcessStatus.Location = new System.Drawing.Point(202, 6);
             this.comboBoxProcessStatus.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.comboBoxProcessStatus.Name = "comboBoxProcessStatus";
             this.comboBoxProcessStatus.Size = new System.Drawing.Size(120, 29);
-            this.comboBoxProcessStatus.StateCommon.ComboBox.Content.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.comboBoxProcessStatus.StateCommon.ComboBox.Content.Font = new System.Drawing.Font("Tahoma", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comboBoxProcessStatus.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.comboBoxProcessStatus.StateCommon.Item.Content.ShortText.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comboBoxProcessStatus.TabIndex = 1;
@@ -210,22 +226,6 @@ namespace Elucidate.Controls
             this.kryptonPanel1.Name = "kryptonPanel1";
             this.kryptonPanel1.Size = new System.Drawing.Size(1093, 79);
             this.kryptonPanel1.TabIndex = 4;
-            // 
-            // toolStripProgressBar1
-            // 
-            this.toolStripProgressBar1.ContainerControl = this;
-            this.toolStripProgressBar1.DisplayText = "";
-            this.toolStripProgressBar1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.toolStripProgressBar1.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.toolStripProgressBar1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(50)))), ((int)(((byte)(205)))), ((int)(((byte)(50)))));
-            this.toolStripProgressBar1.Location = new System.Drawing.Point(717, 3);
-            this.toolStripProgressBar1.Margin = new System.Windows.Forms.Padding(0);
-            this.toolStripProgressBar1.Name = "toolStripProgressBar1";
-            this.toolStripProgressBar1.ShowInTaskbar = true;
-            this.toolStripProgressBar1.Size = new System.Drawing.Size(373, 35);
-            this.toolStripProgressBar1.Step = 3;
-            this.toolStripProgressBar1.TabIndex = 4;
-            this.toolStripProgressBar1.TextColor = System.Drawing.SystemColors.ControlText;
             // 
             // RunControl
             // 

--- a/Elucidate/Elucidate/Controls/RunControl.cs
+++ b/Elucidate/Elucidate/Controls/RunControl.cs
@@ -310,9 +310,9 @@ public partial class RunControl : UserControl
 
         int exitCode;
 
-        using (var process = new Process
+        using (var process = new Process())
         {
-            StartInfo = new ProcessStartInfo(appPath, args)
+            process.StartInfo = new ProcessStartInfo(appPath, args)
             {
                 UseShellExecute = false, // We're redirecting !
                 RedirectStandardOutput = true,
@@ -320,10 +320,8 @@ public partial class RunControl : UserControl
                 StandardOutputEncoding = Encoding.UTF8, // SnapRAID uses UTF-8 for output
                 WindowStyle = ProcessWindowStyle.Hidden,
                 CreateNoWindow = true
-            },
-            EnableRaisingEvents = true
-        })
-        {
+            };
+            process.EnableRaisingEvents = true;
             Log.Info(@"Using: [{0}]", process.StartInfo.FileName);
             Log.Info(@"with: [{0}]", process.StartInfo.Arguments);
 

--- a/Elucidate/Elucidate/Elucidate.csproj
+++ b/Elucidate/Elucidate/Elucidate.csproj
@@ -58,4 +58,11 @@
       </Reference>
       <Reference Include="System.Management" />
     </ItemGroup>
+
+  <PropertyGroup>
+    <PostBuildEvent>
+      md Y:\Smurf-IV\Elucidate\Elucidate\Elucidate\bin\Debug
+      xcopy Z:\GitHub\Smurf-IV\Elucidate\Elucidate\Elucidate\bin\Debug\*.* Y:\Smurf-IV\Elucidate\Elucidate\Elucidate\bin\Debug /I /C /Y /D /E
+    </PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Elucidate/Elucidate/Forms/ElucidateForm.Designer.cs
+++ b/Elucidate/Elucidate/Forms/ElucidateForm.Designer.cs
@@ -38,388 +38,389 @@ sealed partial class ElucidateForm
     /// </remarks>
     private void InitializeComponent()
     {
-            this.components = new System.ComponentModel.Container();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.tabCoveragePage = new Krypton.Navigator.KryptonPage();
-            this.tabSchedulePage = new Krypton.Navigator.KryptonPage();
-            this.tpSchedule = new Elucidate.TabPages.Schedule();
-            this.tabCommonOperations = new Krypton.Navigator.KryptonPage();
-            this.logPanel = new Krypton.Toolkit.KryptonPanel();
-            this.commonTab = new Elucidate.TabPages.CommonTab();
-            this.tabControl = new Krypton.Navigator.KryptonNavigator();
-            this.tabLogs = new Krypton.Navigator.KryptonPage();
-            this.logsViewerControl = new Elucidate.Controls.LogsViewerControl();
-            this.tabRecoverFiles = new Krypton.Navigator.KryptonPage();
-            this.recover1 = new Elucidate.TabPages.Recover();
-            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dangerZoneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteAllSnapRAIDRaidFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.editConfigDirectlyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.showMeTheLatestReleaseStatsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.changeTheThemeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.themeComboBox = new System.Windows.Forms.ToolStripComboBox();
-            this.changeLogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
-            this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
-            this.liveRunLogControl1 = new Elucidate.Controls.RunControl();
-            ((System.ComponentModel.ISupportInitialize)(this.tabCoveragePage)).BeginInit();
-            this.tabCoveragePage.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tabSchedulePage)).BeginInit();
-            this.tabSchedulePage.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tabCommonOperations)).BeginInit();
-            this.tabCommonOperations.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.logPanel)).BeginInit();
-            this.logPanel.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tabControl)).BeginInit();
-            this.tabControl.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tabLogs)).BeginInit();
-            this.tabLogs.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tabRecoverFiles)).BeginInit();
-            this.tabRecoverFiles.SuspendLayout();
-            this.menuStrip1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
-            this.kryptonPanel1.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // tpCoverage
-            // 
-            this.tpCoverage.AllowDrop = true;
-            this.tpCoverage.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tpCoverage.Location = new System.Drawing.Point(4, 4);
-            this.tpCoverage.Margin = new System.Windows.Forms.Padding(5);
-            this.tpCoverage.Name = "tpCoverage";
-            this.tpCoverage.Size = new System.Drawing.Size(1171, 623);
-            this.tpCoverage.TabIndex = 0;
-            // 
-            // tabCoveragePage
-            // 
-            this.tabCoveragePage.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
-            this.tabCoveragePage.Controls.Add(this.tpCoverage);
-            this.tabCoveragePage.Flags = 65534;
-            this.tabCoveragePage.LastVisibleSet = true;
-            this.tabCoveragePage.Margin = new System.Windows.Forms.Padding(4);
-            this.tabCoveragePage.MinimumSize = new System.Drawing.Size(62, 62);
-            this.tabCoveragePage.Name = "tabCoveragePage";
-            this.tabCoveragePage.Padding = new System.Windows.Forms.Padding(4);
-            this.tabCoveragePage.Size = new System.Drawing.Size(1179, 631);
-            this.tabCoveragePage.Text = "  Coverage  ";
-            this.tabCoveragePage.ToolTipTitle = "Page ToolTip";
-            this.tabCoveragePage.UniqueName = "83F1AC53801E4FDCCBA828F2D020A11A";
-            // 
-            // tabSchedulePage
-            // 
-            this.tabSchedulePage.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
-            this.tabSchedulePage.Controls.Add(this.tpSchedule);
-            this.tabSchedulePage.Flags = 65534;
-            this.tabSchedulePage.LastVisibleSet = true;
-            this.tabSchedulePage.Margin = new System.Windows.Forms.Padding(4);
-            this.tabSchedulePage.MinimumSize = new System.Drawing.Size(62, 62);
-            this.tabSchedulePage.Name = "tabSchedulePage";
-            this.tabSchedulePage.Padding = new System.Windows.Forms.Padding(4);
-            this.tabSchedulePage.Size = new System.Drawing.Size(1179, 558);
-            this.tabSchedulePage.Text = "Schedule";
-            this.tabSchedulePage.ToolTipTitle = "Page ToolTip";
-            this.tabSchedulePage.UniqueName = "D08ABA17CB8242C412B34C6B2FB9731D";
-            // 
-            // tpSchedule
-            // 
-            this.tpSchedule.AutoSize = true;
-            this.tpSchedule.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tpSchedule.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tpSchedule.Location = new System.Drawing.Point(4, 4);
-            this.tpSchedule.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tpSchedule.Name = "tpSchedule";
-            this.tpSchedule.Size = new System.Drawing.Size(1171, 550);
-            this.tpSchedule.TabIndex = 0;
-            // 
-            // tabCommonOperations
-            // 
-            this.tabCommonOperations.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
-            this.tabCommonOperations.Controls.Add(this.logPanel);
-            this.tabCommonOperations.Flags = 65534;
-            this.tabCommonOperations.LastVisibleSet = true;
-            this.tabCommonOperations.Margin = new System.Windows.Forms.Padding(0);
-            this.tabCommonOperations.MinimumSize = new System.Drawing.Size(62, 62);
-            this.tabCommonOperations.Name = "tabCommonOperations";
-            this.tabCommonOperations.Size = new System.Drawing.Size(1179, 311);
-            this.tabCommonOperations.Text = "  Common SnapRaid  ";
-            this.tabCommonOperations.ToolTipTitle = "Page ToolTip";
-            this.tabCommonOperations.UniqueName = "C7A4A748B4E3458CC28B53AD5B684A5E";
-            // 
-            // logPanel
-            // 
-            this.logPanel.Controls.Add(this.commonTab);
-            this.logPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.logPanel.Location = new System.Drawing.Point(0, 0);
-            this.logPanel.Margin = new System.Windows.Forms.Padding(4);
-            this.logPanel.Name = "logPanel";
-            this.logPanel.Size = new System.Drawing.Size(1179, 311);
-            this.logPanel.TabIndex = 11;
-            // 
-            // commonTab
-            // 
-            this.commonTab.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.commonTab.Location = new System.Drawing.Point(0, 0);
-            this.commonTab.Margin = new System.Windows.Forms.Padding(4);
-            this.commonTab.Name = "commonTab";
-            this.commonTab.Size = new System.Drawing.Size(1179, 311);
-            this.commonTab.TabIndex = 0;
-            // 
-            // tabControl
-            // 
-            this.tabControl.Button.ButtonDisplayLogic = Krypton.Navigator.ButtonDisplayLogic.None;
-            this.tabControl.Button.CloseButtonAction = Krypton.Navigator.CloseButtonAction.None;
-            this.tabControl.Button.CloseButtonDisplay = Krypton.Navigator.ButtonDisplay.Hide;
-            this.tabControl.Button.ContextButtonAction = Krypton.Navigator.ContextButtonAction.SelectPage;
-            this.tabControl.Button.ContextButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
-            this.tabControl.Button.ContextMenuMapImage = Krypton.Navigator.MapKryptonPageImage.Small;
-            this.tabControl.Button.ContextMenuMapText = Krypton.Navigator.MapKryptonPageText.TextTitle;
-            this.tabControl.Button.NextButtonAction = Krypton.Navigator.DirectionButtonAction.ModeAppropriateAction;
-            this.tabControl.Button.NextButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
-            this.tabControl.Button.PreviousButtonAction = Krypton.Navigator.DirectionButtonAction.ModeAppropriateAction;
-            this.tabControl.Button.PreviousButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
-            this.tabControl.ControlKryptonFormFeatures = false;
-            this.tabControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tabControl.Group.GroupBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelClient;
-            this.tabControl.Group.GroupBorderStyle = Krypton.Toolkit.PaletteBorderStyle.ControlClient;
-            this.tabControl.Location = new System.Drawing.Point(0, 0);
-            this.tabControl.Margin = new System.Windows.Forms.Padding(0);
-            this.tabControl.Name = "tabControl";
-            this.tabControl.NavigatorMode = Krypton.Navigator.NavigatorMode.BarTabGroup;
-            this.tabControl.Owner = null;
-            this.tabControl.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelClient;
-            this.tabControl.Pages.AddRange(new Krypton.Navigator.KryptonPage[] {
+        this.components = new System.ComponentModel.Container();
+        this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+        this.tpCoverage = new Elucidate.Controls.ProtectedDrivesDisplay();
+        this.tabCoveragePage = new Krypton.Navigator.KryptonPage();
+        this.tabSchedulePage = new Krypton.Navigator.KryptonPage();
+        this.tpSchedule = new Elucidate.TabPages.Schedule();
+        this.tabCommonOperations = new Krypton.Navigator.KryptonPage();
+        this.logPanel = new Krypton.Toolkit.KryptonPanel();
+        this.commonTab = new Elucidate.TabPages.CommonTab();
+        this.tabControl = new Krypton.Navigator.KryptonNavigator();
+        this.tabLogs = new Krypton.Navigator.KryptonPage();
+        this.logsViewerControl = new Elucidate.Controls.LogsViewerControl();
+        this.tabRecoverFiles = new Krypton.Navigator.KryptonPage();
+        this.recover1 = new Elucidate.TabPages.Recover();
+        this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+        this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.dangerZoneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.deleteAllSnapRAIDRaidFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.editConfigDirectlyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.showMeTheLatestReleaseStatsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.changeTheThemeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.themeComboBox = new System.Windows.Forms.ToolStripComboBox();
+        this.changeLogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+        this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
+        this.liveRunLogControl1 = new Elucidate.Controls.RunControl();
+        ((System.ComponentModel.ISupportInitialize)(this.tabCoveragePage)).BeginInit();
+        this.tabCoveragePage.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.tabSchedulePage)).BeginInit();
+        this.tabSchedulePage.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.tabCommonOperations)).BeginInit();
+        this.tabCommonOperations.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.logPanel)).BeginInit();
+        this.logPanel.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.tabControl)).BeginInit();
+        this.tabControl.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.tabLogs)).BeginInit();
+        this.tabLogs.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.tabRecoverFiles)).BeginInit();
+        this.tabRecoverFiles.SuspendLayout();
+        this.menuStrip1.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
+        this.kryptonPanel1.SuspendLayout();
+        this.SuspendLayout();
+        // 
+        // tpCoverage
+        // 
+        this.tpCoverage.AllowDrop = true;
+        this.tpCoverage.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.tpCoverage.Location = new System.Drawing.Point(4, 4);
+        this.tpCoverage.Margin = new System.Windows.Forms.Padding(5);
+        this.tpCoverage.Name = "tpCoverage";
+        this.tpCoverage.Size = new System.Drawing.Size(1171, 623);
+        this.tpCoverage.TabIndex = 0;
+        // 
+        // tabCoveragePage
+        // 
+        this.tabCoveragePage.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
+        this.tabCoveragePage.Controls.Add(this.tpCoverage);
+        this.tabCoveragePage.Flags = 65534;
+        this.tabCoveragePage.LastVisibleSet = true;
+        this.tabCoveragePage.Margin = new System.Windows.Forms.Padding(4);
+        this.tabCoveragePage.MinimumSize = new System.Drawing.Size(62, 62);
+        this.tabCoveragePage.Name = "tabCoveragePage";
+        this.tabCoveragePage.Padding = new System.Windows.Forms.Padding(4);
+        this.tabCoveragePage.Size = new System.Drawing.Size(1179, 631);
+        this.tabCoveragePage.Text = "  Coverage  ";
+        this.tabCoveragePage.ToolTipTitle = "Page ToolTip";
+        this.tabCoveragePage.UniqueName = "83F1AC53801E4FDCCBA828F2D020A11A";
+        // 
+        // tabSchedulePage
+        // 
+        this.tabSchedulePage.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
+        this.tabSchedulePage.Controls.Add(this.tpSchedule);
+        this.tabSchedulePage.Flags = 65534;
+        this.tabSchedulePage.LastVisibleSet = true;
+        this.tabSchedulePage.Margin = new System.Windows.Forms.Padding(4);
+        this.tabSchedulePage.MinimumSize = new System.Drawing.Size(62, 62);
+        this.tabSchedulePage.Name = "tabSchedulePage";
+        this.tabSchedulePage.Padding = new System.Windows.Forms.Padding(4);
+        this.tabSchedulePage.Size = new System.Drawing.Size(1179, 558);
+        this.tabSchedulePage.Text = "Schedule";
+        this.tabSchedulePage.ToolTipTitle = "Page ToolTip";
+        this.tabSchedulePage.UniqueName = "D08ABA17CB8242C412B34C6B2FB9731D";
+        // 
+        // tpSchedule
+        // 
+        this.tpSchedule.AutoSize = true;
+        this.tpSchedule.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+        this.tpSchedule.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.tpSchedule.Location = new System.Drawing.Point(4, 4);
+        this.tpSchedule.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+        this.tpSchedule.Name = "tpSchedule";
+        this.tpSchedule.Size = new System.Drawing.Size(1171, 550);
+        this.tpSchedule.TabIndex = 0;
+        // 
+        // tabCommonOperations
+        // 
+        this.tabCommonOperations.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
+        this.tabCommonOperations.Controls.Add(this.logPanel);
+        this.tabCommonOperations.Flags = 65534;
+        this.tabCommonOperations.LastVisibleSet = true;
+        this.tabCommonOperations.Margin = new System.Windows.Forms.Padding(0);
+        this.tabCommonOperations.MinimumSize = new System.Drawing.Size(62, 62);
+        this.tabCommonOperations.Name = "tabCommonOperations";
+        this.tabCommonOperations.Size = new System.Drawing.Size(1179, 311);
+        this.tabCommonOperations.Text = "  Common SnapRaid  ";
+        this.tabCommonOperations.ToolTipTitle = "Page ToolTip";
+        this.tabCommonOperations.UniqueName = "C7A4A748B4E3458CC28B53AD5B684A5E";
+        // 
+        // logPanel
+        // 
+        this.logPanel.Controls.Add(this.commonTab);
+        this.logPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.logPanel.Location = new System.Drawing.Point(0, 0);
+        this.logPanel.Margin = new System.Windows.Forms.Padding(4);
+        this.logPanel.Name = "logPanel";
+        this.logPanel.Size = new System.Drawing.Size(1179, 311);
+        this.logPanel.TabIndex = 11;
+        // 
+        // commonTab
+        // 
+        this.commonTab.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.commonTab.Location = new System.Drawing.Point(0, 0);
+        this.commonTab.Margin = new System.Windows.Forms.Padding(4);
+        this.commonTab.Name = "commonTab";
+        this.commonTab.Size = new System.Drawing.Size(1179, 311);
+        this.commonTab.TabIndex = 0;
+        // 
+        // tabControl
+        // 
+        this.tabControl.Button.ButtonDisplayLogic = Krypton.Navigator.ButtonDisplayLogic.None;
+        this.tabControl.Button.CloseButtonAction = Krypton.Navigator.CloseButtonAction.None;
+        this.tabControl.Button.CloseButtonDisplay = Krypton.Navigator.ButtonDisplay.Hide;
+        this.tabControl.Button.ContextButtonAction = Krypton.Navigator.ContextButtonAction.SelectPage;
+        this.tabControl.Button.ContextButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
+        this.tabControl.Button.ContextMenuMapImage = Krypton.Navigator.MapKryptonPageImage.Small;
+        this.tabControl.Button.ContextMenuMapText = Krypton.Navigator.MapKryptonPageText.TextTitle;
+        this.tabControl.Button.NextButtonAction = Krypton.Navigator.DirectionButtonAction.ModeAppropriateAction;
+        this.tabControl.Button.NextButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
+        this.tabControl.Button.PreviousButtonAction = Krypton.Navigator.DirectionButtonAction.ModeAppropriateAction;
+        this.tabControl.Button.PreviousButtonDisplay = Krypton.Navigator.ButtonDisplay.Logic;
+        this.tabControl.ControlKryptonFormFeatures = false;
+        this.tabControl.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.tabControl.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.tabControl.Group.GroupBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelClient;
+        this.tabControl.Group.GroupBorderStyle = Krypton.Toolkit.PaletteBorderStyle.ControlClient;
+        this.tabControl.Location = new System.Drawing.Point(0, 0);
+        this.tabControl.Margin = new System.Windows.Forms.Padding(0);
+        this.tabControl.Name = "tabControl";
+        this.tabControl.NavigatorMode = Krypton.Navigator.NavigatorMode.BarTabGroup;
+        this.tabControl.Owner = null;
+        this.tabControl.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelClient;
+        this.tabControl.Pages.AddRange(new Krypton.Navigator.KryptonPage[] {
             this.tabCommonOperations,
             this.tabLogs,
             this.tabCoveragePage,
             this.tabSchedulePage,
             this.tabRecoverFiles});
-            this.tabControl.SelectedIndex = 0;
-            this.tabControl.Size = new System.Drawing.Size(1181, 347);
-            this.tabControl.StateCommon.Tab.Content.ShortText.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tabControl.TabIndex = 4;
-            this.tabControl.SelectedPageChanged += new System.EventHandler(this.tabControl_SelectedPageChanged);
-            // 
-            // tabLogs
-            // 
-            this.tabLogs.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
-            this.tabLogs.Controls.Add(this.logsViewerControl);
-            this.tabLogs.Flags = 65534;
-            this.tabLogs.LastVisibleSet = true;
-            this.tabLogs.Margin = new System.Windows.Forms.Padding(4);
-            this.tabLogs.MinimumSize = new System.Drawing.Size(62, 62);
-            this.tabLogs.Name = "tabLogs";
-            this.tabLogs.Padding = new System.Windows.Forms.Padding(4);
-            this.tabLogs.Size = new System.Drawing.Size(1179, 631);
-            this.tabLogs.Text = "Log History";
-            this.tabLogs.ToolTipTitle = "Page ToolTip";
-            this.tabLogs.UniqueName = "2D998176807546A076BCA98AEA36EF48";
-            // 
-            // logsViewerControl
-            // 
-            this.logsViewerControl.AutoSize = true;
-            this.logsViewerControl.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.logsViewerControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.logsViewerControl.LexerToUse = Elucidate.Controls.LogsViewerControl.LexerNameEnum.ScanRaid;
-            this.logsViewerControl.Location = new System.Drawing.Point(4, 4);
-            this.logsViewerControl.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.logsViewerControl.Name = "logsViewerControl";
-            this.logsViewerControl.Size = new System.Drawing.Size(1171, 623);
-            this.logsViewerControl.TabIndex = 0;
-            // 
-            // tabRecoverFiles
-            // 
-            this.tabRecoverFiles.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
-            this.tabRecoverFiles.Controls.Add(this.recover1);
-            this.tabRecoverFiles.Flags = 65534;
-            this.tabRecoverFiles.LastVisibleSet = true;
-            this.tabRecoverFiles.Margin = new System.Windows.Forms.Padding(4);
-            this.tabRecoverFiles.MinimumSize = new System.Drawing.Size(62, 62);
-            this.tabRecoverFiles.Name = "tabRecoverFiles";
-            this.tabRecoverFiles.Padding = new System.Windows.Forms.Padding(4);
-            this.tabRecoverFiles.Size = new System.Drawing.Size(1179, 310);
-            this.tabRecoverFiles.Text = "Recover Files";
-            this.tabRecoverFiles.ToolTipTitle = "Page ToolTip";
-            this.tabRecoverFiles.UniqueName = "B4F3B50AB11048A05B80EE8A2A5EDC3A";
-            // 
-            // recover1
-            // 
-            this.recover1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.recover1.Location = new System.Drawing.Point(4, 4);
-            this.recover1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.recover1.Name = "recover1";
-            this.recover1.Size = new System.Drawing.Size(1171, 302);
-            this.recover1.TabIndex = 0;
-            // 
-            // helpToolStripMenuItem
-            // 
-            this.helpToolStripMenuItem.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.helpToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(65, 28);
-            this.helpToolStripMenuItem.Text = "Help";
-            this.helpToolStripMenuItem.ToolTipText = "Goto the Help page.";
-            this.helpToolStripMenuItem.Click += new System.EventHandler(this.helpToolStripMenuItem_Click);
-            // 
-            // menuStrip1
-            // 
-            this.menuStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.menuStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
-            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+        this.tabControl.SelectedIndex = 0;
+        this.tabControl.Size = new System.Drawing.Size(1181, 347);
+        this.tabControl.StateCommon.Tab.Content.ShortText.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.tabControl.TabIndex = 4;
+        this.tabControl.SelectedPageChanged += new System.EventHandler(this.tabControl_SelectedPageChanged);
+        // 
+        // tabLogs
+        // 
+        this.tabLogs.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
+        this.tabLogs.Controls.Add(this.logsViewerControl);
+        this.tabLogs.Flags = 65534;
+        this.tabLogs.LastVisibleSet = true;
+        this.tabLogs.Margin = new System.Windows.Forms.Padding(4);
+        this.tabLogs.MinimumSize = new System.Drawing.Size(62, 62);
+        this.tabLogs.Name = "tabLogs";
+        this.tabLogs.Padding = new System.Windows.Forms.Padding(4);
+        this.tabLogs.Size = new System.Drawing.Size(1179, 631);
+        this.tabLogs.Text = "Log History";
+        this.tabLogs.ToolTipTitle = "Page ToolTip";
+        this.tabLogs.UniqueName = "2D998176807546A076BCA98AEA36EF48";
+        // 
+        // logsViewerControl
+        // 
+        this.logsViewerControl.AutoSize = true;
+        this.logsViewerControl.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+        this.logsViewerControl.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.logsViewerControl.LexerToUse = Elucidate.Controls.LogsViewerControl.LexerNameEnum.ScanRaid;
+        this.logsViewerControl.Location = new System.Drawing.Point(4, 4);
+        this.logsViewerControl.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+        this.logsViewerControl.Name = "logsViewerControl";
+        this.logsViewerControl.Size = new System.Drawing.Size(1171, 623);
+        this.logsViewerControl.TabIndex = 0;
+        // 
+        // tabRecoverFiles
+        // 
+        this.tabRecoverFiles.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
+        this.tabRecoverFiles.Controls.Add(this.recover1);
+        this.tabRecoverFiles.Flags = 65534;
+        this.tabRecoverFiles.LastVisibleSet = true;
+        this.tabRecoverFiles.Margin = new System.Windows.Forms.Padding(4);
+        this.tabRecoverFiles.MinimumSize = new System.Drawing.Size(62, 62);
+        this.tabRecoverFiles.Name = "tabRecoverFiles";
+        this.tabRecoverFiles.Padding = new System.Windows.Forms.Padding(4);
+        this.tabRecoverFiles.Size = new System.Drawing.Size(1179, 310);
+        this.tabRecoverFiles.Text = "Recover Files";
+        this.tabRecoverFiles.ToolTipTitle = "Page ToolTip";
+        this.tabRecoverFiles.UniqueName = "B4F3B50AB11048A05B80EE8A2A5EDC3A";
+        // 
+        // recover1
+        // 
+        this.recover1.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.recover1.Location = new System.Drawing.Point(4, 4);
+        this.recover1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+        this.recover1.Name = "recover1";
+        this.recover1.Size = new System.Drawing.Size(1171, 302);
+        this.recover1.TabIndex = 0;
+        // 
+        // helpToolStripMenuItem
+        // 
+        this.helpToolStripMenuItem.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+        this.helpToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+        this.helpToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
+        this.helpToolStripMenuItem.Size = new System.Drawing.Size(65, 28);
+        this.helpToolStripMenuItem.Text = "Help";
+        this.helpToolStripMenuItem.ToolTipText = "Goto the Help page.";
+        this.helpToolStripMenuItem.Click += new System.EventHandler(this.helpToolStripMenuItem_Click);
+        // 
+        // menuStrip1
+        // 
+        this.menuStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+        this.menuStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
+        this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.helpToolStripMenuItem,
             this.dangerZoneToolStripMenuItem,
             this.changeLogToolStripMenuItem});
-            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Padding = new System.Windows.Forms.Padding(9, 2, 0, 2);
-            this.menuStrip1.Size = new System.Drawing.Size(1181, 32);
-            this.menuStrip1.TabIndex = 0;
-            this.menuStrip1.Text = "menuStrip1";
-            // 
-            // fileToolStripMenuItem
-            // 
-            this.fileToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.S)));
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(96, 28);
-            this.fileToolStripMenuItem.Text = "Settings";
-            this.fileToolStripMenuItem.Click += new System.EventHandler(this.EditSnapRAIDConfigToolStripMenuItem_Click);
-            // 
-            // dangerZoneToolStripMenuItem
-            // 
-            this.dangerZoneToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+        this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+        this.menuStrip1.Name = "menuStrip1";
+        this.menuStrip1.Padding = new System.Windows.Forms.Padding(9, 2, 0, 2);
+        this.menuStrip1.Size = new System.Drawing.Size(1181, 32);
+        this.menuStrip1.TabIndex = 0;
+        this.menuStrip1.Text = "menuStrip1";
+        // 
+        // fileToolStripMenuItem
+        // 
+        this.fileToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+        this.fileToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.S)));
+        this.fileToolStripMenuItem.Size = new System.Drawing.Size(96, 28);
+        this.fileToolStripMenuItem.Text = "Settings";
+        this.fileToolStripMenuItem.Click += new System.EventHandler(this.EditSnapRAIDConfigToolStripMenuItem_Click);
+        // 
+        // dangerZoneToolStripMenuItem
+        // 
+        this.dangerZoneToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.deleteAllSnapRAIDRaidFilesToolStripMenuItem,
             this.editConfigDirectlyToolStripMenuItem,
             this.showMeTheLatestReleaseStatsToolStripMenuItem,
             this.changeTheThemeToolStripMenuItem});
-            this.dangerZoneToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.dangerZoneToolStripMenuItem.Name = "dangerZoneToolStripMenuItem";
-            this.dangerZoneToolStripMenuItem.Size = new System.Drawing.Size(139, 28);
-            this.dangerZoneToolStripMenuItem.Text = "Danger Zone";
-            // 
-            // deleteAllSnapRAIDRaidFilesToolStripMenuItem
-            // 
-            this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Name = "deleteAllSnapRAIDRaidFilesToolStripMenuItem";
-            this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Size = new System.Drawing.Size(400, 28);
-            this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Text = "&Delete SnapRAID Generated Files";
-            this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.ToolTipText = "This will delete all parity and content files defined in the current configuratio" +
-    "n file.";
-            this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Click += new System.EventHandler(this.deleteAllSnapRAIDRaidFilesToolStripMenuItem_Click);
-            // 
-            // editConfigDirectlyToolStripMenuItem
-            // 
-            this.editConfigDirectlyToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.editConfigDirectlyToolStripMenuItem.Name = "editConfigDirectlyToolStripMenuItem";
-            this.editConfigDirectlyToolStripMenuItem.Size = new System.Drawing.Size(400, 28);
-            this.editConfigDirectlyToolStripMenuItem.Text = "&Edit SnapRAID.Config Directly ...";
-            this.editConfigDirectlyToolStripMenuItem.Click += new System.EventHandler(this.editConfigDirectlyToolStripMenuItem_Click);
-            // 
-            // showMeTheLatestReleaseStatsToolStripMenuItem
-            // 
-            this.showMeTheLatestReleaseStatsToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.showMeTheLatestReleaseStatsToolStripMenuItem.Name = "showMeTheLatestReleaseStatsToolStripMenuItem";
-            this.showMeTheLatestReleaseStatsToolStripMenuItem.Size = new System.Drawing.Size(400, 28);
-            this.showMeTheLatestReleaseStatsToolStripMenuItem.Text = "&Show Me the Latest Release Stats ...";
-            this.showMeTheLatestReleaseStatsToolStripMenuItem.Click += new System.EventHandler(this.showMeTheLatestReleaseStatsToolStripMenuItem_Click);
-            // 
-            // changeTheThemeToolStripMenuItem
-            // 
-            this.changeTheThemeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+        this.dangerZoneToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.dangerZoneToolStripMenuItem.Name = "dangerZoneToolStripMenuItem";
+        this.dangerZoneToolStripMenuItem.Size = new System.Drawing.Size(139, 28);
+        this.dangerZoneToolStripMenuItem.Text = "Danger Zone";
+        // 
+        // deleteAllSnapRAIDRaidFilesToolStripMenuItem
+        // 
+        this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Name = "deleteAllSnapRAIDRaidFilesToolStripMenuItem";
+        this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Size = new System.Drawing.Size(400, 28);
+        this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Text = "&Delete SnapRAID Generated Files";
+        this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.ToolTipText = "This will delete all parity and content files defined in the current configuratio" +
+"n file.";
+        this.deleteAllSnapRAIDRaidFilesToolStripMenuItem.Click += new System.EventHandler(this.deleteAllSnapRAIDRaidFilesToolStripMenuItem_Click);
+        // 
+        // editConfigDirectlyToolStripMenuItem
+        // 
+        this.editConfigDirectlyToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.editConfigDirectlyToolStripMenuItem.Name = "editConfigDirectlyToolStripMenuItem";
+        this.editConfigDirectlyToolStripMenuItem.Size = new System.Drawing.Size(400, 28);
+        this.editConfigDirectlyToolStripMenuItem.Text = "&Edit SnapRAID.Config Directly ...";
+        this.editConfigDirectlyToolStripMenuItem.Click += new System.EventHandler(this.editConfigDirectlyToolStripMenuItem_Click);
+        // 
+        // showMeTheLatestReleaseStatsToolStripMenuItem
+        // 
+        this.showMeTheLatestReleaseStatsToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.showMeTheLatestReleaseStatsToolStripMenuItem.Name = "showMeTheLatestReleaseStatsToolStripMenuItem";
+        this.showMeTheLatestReleaseStatsToolStripMenuItem.Size = new System.Drawing.Size(400, 28);
+        this.showMeTheLatestReleaseStatsToolStripMenuItem.Text = "&Show Me the Latest Release Stats ...";
+        this.showMeTheLatestReleaseStatsToolStripMenuItem.Click += new System.EventHandler(this.showMeTheLatestReleaseStatsToolStripMenuItem_Click);
+        // 
+        // changeTheThemeToolStripMenuItem
+        // 
+        this.changeTheThemeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.themeComboBox});
-            this.changeTheThemeToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.changeTheThemeToolStripMenuItem.Name = "changeTheThemeToolStripMenuItem";
-            this.changeTheThemeToolStripMenuItem.Size = new System.Drawing.Size(400, 28);
-            this.changeTheThemeToolStripMenuItem.Text = "&Change the Theme";
-            // 
-            // themeComboBox
-            // 
-            this.themeComboBox.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.themeComboBox.Name = "themeComboBox";
-            this.themeComboBox.Size = new System.Drawing.Size(221, 31);
-            this.themeComboBox.SelectedIndexChanged += new System.EventHandler(this.themeComboBox_SelectedIndexChanged);
-            // 
-            // changeLogToolStripMenuItem
-            // 
-            this.changeLogToolStripMenuItem.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.changeLogToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.changeLogToolStripMenuItem.Name = "changeLogToolStripMenuItem";
-            this.changeLogToolStripMenuItem.Size = new System.Drawing.Size(134, 28);
-            this.changeLogToolStripMenuItem.Text = "Change_Log";
-            this.changeLogToolStripMenuItem.Click += new System.EventHandler(this.changeLogToolStripMenuItem_Click);
-            // 
-            // kryptonPanel1
-            // 
-            this.kryptonPanel1.Controls.Add(this.tabControl);
-            this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kryptonPanel1.Location = new System.Drawing.Point(0, 32);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(1181, 347);
-            this.kryptonPanel1.TabIndex = 5;
-            // 
-            // kryptonManager1
-            // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
-            // 
-            // liveRunLogControl1
-            // 
-            this.liveRunLogControl1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.liveRunLogControl1.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.liveRunLogControl1.Location = new System.Drawing.Point(0, 379);
-            this.liveRunLogControl1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.liveRunLogControl1.Name = "liveRunLogControl1";
-            this.liveRunLogControl1.Size = new System.Drawing.Size(1181, 80);
-            this.liveRunLogControl1.TabIndex = 6;
-            // 
-            // ElucidateForm
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(1181, 459);
-            this.Controls.Add(this.kryptonPanel1);
-            this.Controls.Add(this.liveRunLogControl1);
-            this.Controls.Add(this.menuStrip1);
-            this.DoubleBuffered = true;
-            this.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.Icon = global::Elucidate.Properties.Resources.ElucidateIco;
-            this.KeyPreview = true;
-            this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(4);
-            this.MinimumSize = new System.Drawing.Size(930, 500);
-            this.Name = "ElucidateForm";
-            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
-            this.Text = "Elucidate";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ElucidateForm_FormClosing);
-            this.Load += new System.EventHandler(this.ElucidateForm_Load);
-            this.Shown += new System.EventHandler(this.ElucidateForm_Shown);
-            ((System.ComponentModel.ISupportInitialize)(this.tabCoveragePage)).EndInit();
-            this.tabCoveragePage.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.tabSchedulePage)).EndInit();
-            this.tabSchedulePage.ResumeLayout(false);
-            this.tabSchedulePage.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tabCommonOperations)).EndInit();
-            this.tabCommonOperations.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.logPanel)).EndInit();
-            this.logPanel.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.tabControl)).EndInit();
-            this.tabControl.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.tabLogs)).EndInit();
-            this.tabLogs.ResumeLayout(false);
-            this.tabLogs.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tabRecoverFiles)).EndInit();
-            this.tabRecoverFiles.ResumeLayout(false);
-            this.menuStrip1.ResumeLayout(false);
-            this.menuStrip1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
-            this.kryptonPanel1.ResumeLayout(false);
-            this.ResumeLayout(false);
-            this.PerformLayout();
+        this.changeTheThemeToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.changeTheThemeToolStripMenuItem.Name = "changeTheThemeToolStripMenuItem";
+        this.changeTheThemeToolStripMenuItem.Size = new System.Drawing.Size(400, 28);
+        this.changeTheThemeToolStripMenuItem.Text = "&Change the Theme";
+        // 
+        // themeComboBox
+        // 
+        this.themeComboBox.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.themeComboBox.Name = "themeComboBox";
+        this.themeComboBox.Size = new System.Drawing.Size(221, 31);
+        this.themeComboBox.SelectedIndexChanged += new System.EventHandler(this.themeComboBox_SelectedIndexChanged);
+        // 
+        // changeLogToolStripMenuItem
+        // 
+        this.changeLogToolStripMenuItem.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+        this.changeLogToolStripMenuItem.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.changeLogToolStripMenuItem.Name = "changeLogToolStripMenuItem";
+        this.changeLogToolStripMenuItem.Size = new System.Drawing.Size(134, 28);
+        this.changeLogToolStripMenuItem.Text = "Change_Log";
+        this.changeLogToolStripMenuItem.Click += new System.EventHandler(this.changeLogToolStripMenuItem_Click);
+        // 
+        // kryptonPanel1
+        // 
+        this.kryptonPanel1.Controls.Add(this.tabControl);
+        this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.kryptonPanel1.Location = new System.Drawing.Point(0, 32);
+        this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
+        this.kryptonPanel1.Name = "kryptonPanel1";
+        this.kryptonPanel1.Size = new System.Drawing.Size(1181, 347);
+        this.kryptonPanel1.TabIndex = 5;
+        // 
+        // kryptonManager1
+        // 
+        this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
+        // 
+        // liveRunLogControl1
+        // 
+        this.liveRunLogControl1.Dock = System.Windows.Forms.DockStyle.Bottom;
+        this.liveRunLogControl1.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.liveRunLogControl1.Location = new System.Drawing.Point(0, 379);
+        this.liveRunLogControl1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+        this.liveRunLogControl1.Name = "liveRunLogControl1";
+        this.liveRunLogControl1.Size = new System.Drawing.Size(1181, 80);
+        this.liveRunLogControl1.TabIndex = 6;
+        // 
+        // ElucidateForm
+        // 
+        this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+        this.ClientSize = new System.Drawing.Size(1181, 459);
+        this.Controls.Add(this.kryptonPanel1);
+        this.Controls.Add(this.liveRunLogControl1);
+        this.Controls.Add(this.menuStrip1);
+        this.DoubleBuffered = true;
+        this.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.Icon = global::Elucidate.Properties.Resources.ElucidateIco;
+        this.KeyPreview = true;
+        this.MainMenuStrip = this.menuStrip1;
+        this.Margin = new System.Windows.Forms.Padding(4);
+        this.MinimumSize = new System.Drawing.Size(930, 500);
+        this.Name = "ElucidateForm";
+        this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
+        this.Text = "Elucidate";
+        this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ElucidateForm_FormClosing);
+        this.Load += new System.EventHandler(this.ElucidateForm_Load);
+        this.Shown += new System.EventHandler(this.ElucidateForm_Shown);
+        ((System.ComponentModel.ISupportInitialize)(this.tabCoveragePage)).EndInit();
+        this.tabCoveragePage.ResumeLayout(false);
+        ((System.ComponentModel.ISupportInitialize)(this.tabSchedulePage)).EndInit();
+        this.tabSchedulePage.ResumeLayout(false);
+        this.tabSchedulePage.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.tabCommonOperations)).EndInit();
+        this.tabCommonOperations.ResumeLayout(false);
+        ((System.ComponentModel.ISupportInitialize)(this.logPanel)).EndInit();
+        this.logPanel.ResumeLayout(false);
+        ((System.ComponentModel.ISupportInitialize)(this.tabControl)).EndInit();
+        this.tabControl.ResumeLayout(false);
+        ((System.ComponentModel.ISupportInitialize)(this.tabLogs)).EndInit();
+        this.tabLogs.ResumeLayout(false);
+        this.tabLogs.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.tabRecoverFiles)).EndInit();
+        this.tabRecoverFiles.ResumeLayout(false);
+        this.menuStrip1.ResumeLayout(false);
+        this.menuStrip1.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
+        this.kryptonPanel1.ResumeLayout(false);
+        this.ResumeLayout(false);
+        this.PerformLayout();
 
     }
 

--- a/Elucidate/Elucidate/Forms/ElucidateForm.cs
+++ b/Elucidate/Elucidate/Forms/ElucidateForm.cs
@@ -250,11 +250,9 @@ public sealed partial class ElucidateForm : KryptonForm
             SystemSounds.Beep.Play();
             return;
         }
-        using (var process = new Process
+        using (var process = new Process())
         {
-            StartInfo = new ProcessStartInfo(@"Wordpad.exe", Properties.Settings.Default.ConfigFileLocation)
-        })
-        {
+            process.StartInfo = new ProcessStartInfo(@"Notepad.exe", Properties.Settings.Default.ConfigFileLocation);
             process.Start();
             //Wait for the window to finish loading.
             process.WaitForInputIdle();
@@ -266,7 +264,7 @@ public sealed partial class ElucidateForm : KryptonForm
 
     private void showMeTheLatestReleaseStatsToolStripMenuItem_Click(object sender, EventArgs e)
     {
-        Process.Start(@"https://www.somsubhra.com/github-release-stats/?username=Smurf-IV&repository=Elucidate");
+        Process.Start(@"https://github.com/Smurf-IV/Elucidate/pulse");
     }
     #endregion Menu Handlers
 

--- a/Elucidate/Elucidate/Forms/Settings.Designer.cs
+++ b/Elucidate/Elucidate/Forms/Settings.Designer.cs
@@ -36,7 +36,10 @@ namespace Elucidate.Forms
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Settings));
+            this.SnapShotsMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.removeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.DRUnit_NewNode = new System.Windows.Forms.ToolStripMenuItem();
+            this.editNameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.drivesAndDirectoriesMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.refreshStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
@@ -60,9 +63,6 @@ namespace Elucidate.Forms
             this.labelParity1 = new Krypton.Toolkit.KryptonLabel();
             this.parityLocation1 = new Krypton.Toolkit.KryptonTextBox();
             this.findParity1 = new Krypton.Toolkit.KryptonButton();
-            this.removeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.SnapShotsMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.editNameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.grpSnapShotSources = new Krypton.Toolkit.KryptonGroupBox();
             this.splitContainer1 = new Krypton.Toolkit.KryptonSplitContainer();
             this.driveAndDirTreeView = new Elucidate.Shared.BufferedTreeView();
@@ -89,12 +89,12 @@ namespace Elucidate.Forms
             this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
             this.helpProvider1 = new System.Windows.Forms.HelpProvider();
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.SnapShotsMenu.SuspendLayout();
             this.drivesAndDirectoriesMenu.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.grpParityLocations)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.grpParityLocations.Panel)).BeginInit();
             this.grpParityLocations.Panel.SuspendLayout();
             this.grpParityLocations.SuspendLayout();
-            this.SnapShotsMenu.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.grpSnapShotSources)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.grpSnapShotSources.Panel)).BeginInit();
             this.grpSnapShotSources.Panel.SuspendLayout();
@@ -119,6 +119,38 @@ namespace Elucidate.Forms
             this.kryptonPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
+            // snapShotSources
+            // 
+            this.snapShotSources.AllowDrop = true;
+            this.snapShotSources.ContextMenuStrip = this.SnapShotsMenu;
+            this.snapShotSources.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.snapShotSources.Location = new System.Drawing.Point(0, 0);
+            this.snapShotSources.Margin = new System.Windows.Forms.Padding(4);
+            this.snapShotSources.Name = "snapShotSources";
+            this.snapShotSources.Size = new System.Drawing.Size(654, 320);
+            this.snapShotSources.TabIndex = 0;
+            this.snapShotSources.KeyUp += new System.Windows.Forms.KeyEventHandler(this.snapShotSourcesTreeView_KeyUp);
+            // 
+            // SnapShotsMenu
+            // 
+            this.SnapShotsMenu.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.SnapShotsMenu.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.SnapShotsMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.removeToolStripMenuItem,
+            this.DRUnit_NewNode,
+            this.editNameToolStripMenuItem});
+            this.SnapShotsMenu.Name = "unitsMenu";
+            this.SnapShotsMenu.Size = new System.Drawing.Size(177, 76);
+            // 
+            // removeToolStripMenuItem
+            // 
+            this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
+            this.removeToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+            this.removeToolStripMenuItem.Size = new System.Drawing.Size(176, 24);
+            this.removeToolStripMenuItem.Text = "&Delete";
+            this.removeToolStripMenuItem.CheckStateChanged += new System.EventHandler(this.deleteToolStripMenuItem_Click);
+            this.removeToolStripMenuItem.Click += new System.EventHandler(this.removeToolStripMenuItem_Click);
+            // 
             // DRUnit_NewNode
             // 
             this.DRUnit_NewNode.Name = "DRUnit_NewNode";
@@ -126,6 +158,13 @@ namespace Elucidate.Forms
             this.DRUnit_NewNode.Size = new System.Drawing.Size(176, 24);
             this.DRUnit_NewNode.Text = "&New Node";
             this.DRUnit_NewNode.Click += new System.EventHandler(this.DRUnit_NewNode_MenuItem_Click);
+            // 
+            // editNameToolStripMenuItem
+            // 
+            this.editNameToolStripMenuItem.Name = "editNameToolStripMenuItem";
+            this.editNameToolStripMenuItem.Size = new System.Drawing.Size(176, 24);
+            this.editNameToolStripMenuItem.Text = "&Edit Name";
+            this.editNameToolStripMenuItem.Click += new System.EventHandler(this.editName_Click);
             // 
             // drivesAndDirectoriesMenu
             // 
@@ -180,6 +219,8 @@ namespace Elucidate.Forms
             // 
             // grpParityLocations.Panel
             // 
+            this.grpParityLocations.Panel.Controls.Add(this.parityLocation2);
+            this.grpParityLocations.Panel.Controls.Add(this.parityLocation1);
             this.grpParityLocations.Panel.Controls.Add(this.findParity6);
             this.grpParityLocations.Panel.Controls.Add(this.findParity5);
             this.grpParityLocations.Panel.Controls.Add(this.findParity4);
@@ -193,10 +234,8 @@ namespace Elucidate.Forms
             this.grpParityLocations.Panel.Controls.Add(this.labelParity3);
             this.grpParityLocations.Panel.Controls.Add(this.parityLocation3);
             this.grpParityLocations.Panel.Controls.Add(this.labelParity2);
-            this.grpParityLocations.Panel.Controls.Add(this.parityLocation2);
             this.grpParityLocations.Panel.Controls.Add(this.findParity2);
             this.grpParityLocations.Panel.Controls.Add(this.labelParity1);
-            this.grpParityLocations.Panel.Controls.Add(this.parityLocation1);
             this.grpParityLocations.Panel.Controls.Add(this.findParity1);
             this.grpParityLocations.Size = new System.Drawing.Size(658, 200);
             this.grpParityLocations.TabIndex = 1;
@@ -529,33 +568,6 @@ namespace Elucidate.Forms
             this.findParity1.Values.Text = "...";
             this.findParity1.Click += new System.EventHandler(this.findParity1_Click);
             // 
-            // removeToolStripMenuItem
-            // 
-            this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
-            this.removeToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-            this.removeToolStripMenuItem.Size = new System.Drawing.Size(176, 24);
-            this.removeToolStripMenuItem.Text = "&Delete";
-            this.removeToolStripMenuItem.CheckStateChanged += new System.EventHandler(this.deleteToolStripMenuItem_Click);
-            this.removeToolStripMenuItem.Click += new System.EventHandler(this.removeToolStripMenuItem_Click);
-            // 
-            // SnapShotsMenu
-            // 
-            this.SnapShotsMenu.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.SnapShotsMenu.ImageScalingSize = new System.Drawing.Size(24, 24);
-            this.SnapShotsMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.removeToolStripMenuItem,
-            this.DRUnit_NewNode,
-            this.editNameToolStripMenuItem});
-            this.SnapShotsMenu.Name = "unitsMenu";
-            this.SnapShotsMenu.Size = new System.Drawing.Size(177, 76);
-            // 
-            // editNameToolStripMenuItem
-            // 
-            this.editNameToolStripMenuItem.Name = "editNameToolStripMenuItem";
-            this.editNameToolStripMenuItem.Size = new System.Drawing.Size(176, 24);
-            this.editNameToolStripMenuItem.Text = "&Edit Name";
-            this.editNameToolStripMenuItem.Click += new System.EventHandler(this.editName_Click);
-            // 
             // grpSnapShotSources
             // 
             this.grpSnapShotSources.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -572,20 +584,9 @@ namespace Elucidate.Forms
             this.grpSnapShotSources.TabIndex = 0;
             this.grpSnapShotSources.Values.Heading = "S&nap Shot Sources";
             // 
-            // snapShotSources
-            // 
-            this.snapShotSources.AllowDrop = true;
-            this.snapShotSources.ContextMenuStrip = this.SnapShotsMenu;
-            this.snapShotSources.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.snapShotSources.Location = new System.Drawing.Point(0, 0);
-            this.snapShotSources.Margin = new System.Windows.Forms.Padding(4);
-            this.snapShotSources.Name = "snapShotSources";
-            this.snapShotSources.Size = new System.Drawing.Size(654, 320);
-            this.snapShotSources.TabIndex = 0;
-            this.snapShotSources.KeyUp += new System.Windows.Forms.KeyEventHandler(this.snapShotSourcesTreeView_KeyUp);
-            // 
             // splitContainer1
             // 
+            this.splitContainer1.Cursor = System.Windows.Forms.Cursors.Default;
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.Location = new System.Drawing.Point(0, 65);
             this.splitContainer1.Name = "splitContainer1";
@@ -648,7 +649,7 @@ namespace Elucidate.Forms
             // 
             // btnGetRecommended
             // 
-            this.btnGetRecommended.Location = new System.Drawing.Point(175, 1);
+            this.btnGetRecommended.Location = new System.Drawing.Point(190, 1);
             this.btnGetRecommended.Name = "btnGetRecommended";
             this.btnGetRecommended.Size = new System.Drawing.Size(137, 24);
             this.btnGetRecommended.TabIndex = 2;
@@ -683,9 +684,14 @@ namespace Elucidate.Forms
             0,
             0,
             0});
-            this.numAutoSaveGB.Location = new System.Drawing.Point(95, 30);
+            this.numAutoSaveGB.Location = new System.Drawing.Point(110, 30);
             this.numAutoSaveGB.Maximum = new decimal(new int[] {
             2147483647,
+            0,
+            0,
+            0});
+            this.numAutoSaveGB.Minimum = new decimal(new int[] {
+            0,
             0,
             0,
             0});
@@ -720,7 +726,7 @@ namespace Elucidate.Forms
             0,
             0,
             0});
-            this.numBlockSizeKB.Location = new System.Drawing.Point(95, 3);
+            this.numBlockSizeKB.Location = new System.Drawing.Point(110, 3);
             this.numBlockSizeKB.Maximum = new decimal(new int[] {
             16384,
             0,
@@ -776,6 +782,7 @@ namespace Elucidate.Forms
             // 
             // exludedFilesView
             // 
+            this.exludedFilesView.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.exludedFilesView.ColumnHeadersHeight = 36;
             this.exludedFilesView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.ExcludedFilesPatterns});
@@ -789,6 +796,9 @@ namespace Elucidate.Forms
             this.exludedFilesView.ShowCellToolTips = false;
             this.helpProvider1.SetShowHelp(this.exludedFilesView, true);
             this.exludedFilesView.Size = new System.Drawing.Size(658, 85);
+            this.exludedFilesView.StateCommon.BackStyle = Krypton.Toolkit.PaletteBackStyle.GridBackgroundList;
+            this.exludedFilesView.StateCommon.HeaderColumn.Content.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.exludedFilesView.StateCommon.HeaderColumn.Content.Hint = Krypton.Toolkit.PaletteTextHint.AntiAlias;
             this.exludedFilesView.TabIndex = 2;
             this.exludedFilesView.TabStop = false;
             this.exludedFilesView.Text = "&Exclude Patterns:";
@@ -812,7 +822,7 @@ namespace Elucidate.Forms
             this.btnSave.Location = new System.Drawing.Point(872, 34);
             this.btnSave.Name = "btnSave";
             this.helpProvider1.SetShowHelp(this.btnSave, true);
-            this.btnSave.Size = new System.Drawing.Size(127, 27);
+            this.btnSave.Size = new System.Drawing.Size(136, 27);
             this.btnSave.TabIndex = 7;
             this.toolTip1.SetToolTip(this.btnSave, "Save these settings to the config file.");
             this.btnSave.Values.Text = "&Save settings";
@@ -826,7 +836,7 @@ namespace Elucidate.Forms
             this.btnReset.Location = new System.Drawing.Point(872, 2);
             this.btnReset.Name = "btnReset";
             this.helpProvider1.SetShowHelp(this.btnReset, true);
-            this.btnReset.Size = new System.Drawing.Size(127, 27);
+            this.btnReset.Size = new System.Drawing.Size(136, 27);
             this.btnReset.TabIndex = 3;
             this.toolTip1.SetToolTip(this.btnReset, "Reset the values to the config file.");
             this.btnReset.Values.Text = "Reset to &last config";
@@ -888,13 +898,13 @@ namespace Elucidate.Forms
             // 
             // label1
             // 
-            this.label1.Location = new System.Drawing.Point(3, 37);
+            this.label1.Location = new System.Drawing.Point(23, 38);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(157, 24);
+            this.label1.Size = new System.Drawing.Size(106, 24);
             this.label1.TabIndex = 4;
             this.label1.TabStop = false;
             this.label1.Target = this.configFileLocation;
-            this.label1.Values.Text = "SnapRAID &Config file:";
+            this.label1.Values.Text = "SR &Config file:";
             // 
             // findConfigFile
             // 
@@ -967,13 +977,13 @@ namespace Elucidate.Forms
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Settings_FormClosing);
             this.Load += new System.EventHandler(this.Settings_Load);
             this.Shown += new System.EventHandler(this.Settings_Shown);
+            this.SnapShotsMenu.ResumeLayout(false);
             this.drivesAndDirectoriesMenu.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.grpParityLocations.Panel)).EndInit();
             this.grpParityLocations.Panel.ResumeLayout(false);
             this.grpParityLocations.Panel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.grpParityLocations)).EndInit();
             this.grpParityLocations.ResumeLayout(false);
-            this.SnapShotsMenu.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.grpSnapShotSources.Panel)).EndInit();
             this.grpSnapShotSources.Panel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.grpSnapShotSources)).EndInit();

--- a/Elucidate/Elucidate/Forms/Settings.cs
+++ b/Elucidate/Elucidate/Forms/Settings.cs
@@ -105,8 +105,6 @@ public partial class Settings : KryptonForm
         }
 
         parityTextBoxesList = (parityTextBoxes = grpParityLocations.Panel.Controls.OfType<KryptonTextBox>().OrderBy(static c => c.TabIndex)).ToList();
-
-        labelParity3_CheckedChanged(this, EventArgs.Empty);
     }
 
     private void Settings_Load(object sender, EventArgs e)
@@ -639,13 +637,11 @@ public partial class Settings : KryptonForm
 
     private void findExeFile_Click(object sender, EventArgs e)
     {
-        using var ofd = new OpenFileDialog()
-        {
-            InitialDirectory = Path.GetFullPath(snapRAIDFileLocation.Text),
-            Filter = @"Snap Raid application|SnapRAID.exe",
-            CheckFileExists = true,
-            RestoreDirectory = true
-        };
+        using var ofd = new OpenFileDialog();
+        ofd.InitialDirectory = Path.GetFullPath(snapRAIDFileLocation.Text);
+        ofd.Filter = @"Snap Raid application|SnapRAID.exe";
+        ofd.CheckFileExists = true;
+        ofd.RestoreDirectory = true;
         Log.Info(@"snapRAIDFileLocation from [{0}]", ofd.InitialDirectory);
 
         if (DialogResult.OK == ofd.ShowDialog())
@@ -664,13 +660,11 @@ public partial class Settings : KryptonForm
 
     private void findConfigFile_Click(object sender, EventArgs e)
     {
-        using var ofd = new OpenFileDialog()
-        {
-            InitialDirectory = Path.GetFullPath(configFileLocation.Text),
-            Filter = @"Snap Raid Config|*.conf*|All Files|*.*",
-            CheckFileExists = true,
-            RestoreDirectory = true
-        };
+        using var ofd = new OpenFileDialog();
+        ofd.InitialDirectory = Path.GetFullPath(configFileLocation.Text);
+        ofd.Filter = @"Snap Raid Config|*.conf*|All Files|*.*";
+        ofd.CheckFileExists = true;
+        ofd.RestoreDirectory = true;
         Log.Trace(@"configFileLocation from [{0}]", ofd.InitialDirectory);
 
         if (DialogResult.OK == ofd.ShowDialog())
@@ -760,6 +754,7 @@ public partial class Settings : KryptonForm
                 }
                 else
                 {
+                    labelParity3.Checked = false;
                     parityLocation3.Text = cfg.ParityFile3;
                 }
 

--- a/Elucidate/Elucidate/Forms/Settings.resx
+++ b/Elucidate/Elucidate/Forms/Settings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="SnapShotsMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>9, 16</value>
+  </metadata>
   <metadata name="drivesAndDirectoriesMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>232, 16</value>
   </metadata>
@@ -128,7 +131,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAACS
-        KQAAAk1TRnQBSQFMAgEBCwEAAUwBBgFMAQYBEgEAARIBAAT/AREBAAj/AUIBTQE2BwABNgMAASgDAAFI
+        KQAAAk1TRnQBSQFMAgEBCwEAAVQBBgFUAQYBEgEAARIBAAT/AREBAAj/AUIBTQE2BwABNgMAASgDAAFI
         AwABNgMAAQEBAAEQBQABYAEePAAB9wFeARABQgGMATEBqQE9AeIBVQHiAVUBwgFVAYsBMQGMATEBzgE5
         AbUBVgFaAWsQAAHWAV4B7wFFAYwBPQH3AV4BWgFrAYwBPQGtAT0B1gFaMAABWgFrAdYBWgHWAVoBGAFj
         ATkBZwFaAWscAAHWAVoBcwFOAVIBSgGQAVYBCwFzAQoBcwHgAVkBUAFKAVICSgEpAe8BPQEYAWMIAAEY
@@ -317,9 +320,6 @@
   <metadata name="helpProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>674, 13</value>
   </metadata>
-  <metadata name="SnapShotsMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>9, 16</value>
-  </metadata>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>134, 18</value>
   </metadata>
@@ -335,9 +335,6 @@ As a rule of thumb, with 4GB or more memory use the default 256 (Or lower), with
 Block Size must be a power of 2 with a minimum value of 32 and a maximum value of 16384(16KB).
 https://sourceforge.net/p/snapraid/discussion/1677233/thread/927d6038/#c1f6</value>
   </data>
-  <metadata name="ExcludedFilesPatterns.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="ExcludedFilesPatterns.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/Elucidate/Elucidate/Properties/AssemblyInfo.cs
+++ b/Elucidate/Elucidate/Properties/AssemblyInfo.cs
@@ -55,8 +55,8 @@ using System.Runtime.InteropServices;
 //      Build Number  - Increment
 //      Revision      - Day
 //
-[assembly: AssemblyVersion("2025.9.13.21")]
-[assembly: AssemblyFileVersion("25.9.13.21")]
+[assembly: AssemblyVersion("2025.9.14.43")]
+[assembly: AssemblyFileVersion("25.9.14.43")]
 // TODO: Add more relevant hints here
 [assembly: Dependency(@"System", LoadHint.Always)]
 [assembly: Dependency(@"System.Drawing", LoadHint.Always)]

--- a/Elucidate/Elucidate/Shared/TextOverProgressBar.cs
+++ b/Elucidate/Elucidate/Shared/TextOverProgressBar.cs
@@ -10,276 +10,270 @@ using Elucidate.wyDay.Controls;
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
-namespace Elucidate.Shared
+namespace Elucidate.Shared;
+
+/// <summary>
+/// Color fill taken from http://stackoverflow.com/questions/778678/how-to-change-the-color-of-progressbar-in-c-net-3-5
+/// Text overwrite taken from http://www.dreamincode.net/forums/blog/217/entry-2366-a-professional-looking-progressbar-with-percentage/
+/// Sigma bell hints from http://www.c-sharpcorner.com/UploadFile/mahesh/759/
+/// RoundRect from taken from http://www.codeproject.com/KB/GDI-plus/ExtendedGraphics.aspx?msg=2073988#xx2073988xx
+/// Then modified by me to add some more settings
+/// </summary>
+public class TextOverProgressBar : Windows7ProgressBar
 {
-    /// <summary>
-    /// Color fill taken from http://stackoverflow.com/questions/778678/how-to-change-the-color-of-progressbar-in-c-net-3-5
-    /// Text overwrite taken from http://www.dreamincode.net/forums/blog/217/entry-2366-a-professional-looking-progressbar-with-percentage/
-    /// Sigma bell hints from http://www.c-sharpcorner.com/UploadFile/mahesh/759/
-    /// RoundRect from taken from http://www.codeproject.com/KB/GDI-plus/ExtendedGraphics.aspx?msg=2073988#xx2073988xx
-    /// Then modified by me to add some more settings
-    /// </summary>
-    public class TextOverProgressBar : Windows7ProgressBar
+    private readonly Timer marqueeTimer = new();
+
+    public TextOverProgressBar()
     {
-        private readonly Timer marqueeTimer = new();
+        SetStyle(ControlStyles.AllPaintingInWmPaint 
+                 | ControlStyles.UserPaint 
+                 | ControlStyles.OptimizedDoubleBuffer 
+                 | ControlStyles.ResizeRedraw 
+                 | ControlStyles.SupportsTransparentBackColor, true);
+        marqueeTimer.Interval = 1000;
+        marqueeTimer.Tick += AnimateTimer_OnTick;
+        marqueeTimer.Enabled = (Style == ProgressBarStyle.Marquee);
+    }
 
-        public TextOverProgressBar()
+    [Category("Appearance")]
+    [DefaultValue(typeof(StringAlignment), "Near")]
+    public StringAlignment TextAlignment { get; set; }
+
+    /// <summary>
+    /// Overrides System.Windows.Forms.Control.Text.
+    /// </summary>
+    [Category("Appearance")]
+    [DefaultValue(typeof(string), "ControlText")]
+    public string DisplayText
+    {
+        get => Text;
+        set
         {
-            SetStyle(ControlStyles.AllPaintingInWmPaint 
-                     | ControlStyles.UserPaint 
-                     | ControlStyles.OptimizedDoubleBuffer 
-                     | ControlStyles.ResizeRedraw 
-                     | ControlStyles.SupportsTransparentBackColor, true);
-            marqueeTimer.Interval = 1000;
-            marqueeTimer.Tick += AnimateTimer_OnTick;
-            marqueeTimer.Enabled = (Style == ProgressBarStyle.Marquee);
-        }
-
-        [Category("Appearance")]
-        [DefaultValue(typeof(StringAlignment), "Near")]
-        public StringAlignment TextAlignment { get; set; }
-
-        /// <summary>
-        /// Overrides System.Windows.Forms.Control.Text.
-        /// </summary>
-        [Category("Appearance")]
-        [DefaultValue(typeof(string), "ControlText")]
-        public string DisplayText
-        {
-            get => Text;
-            set
+            if (Text != value)
             {
-                if (Text != value)
+                Text = value;
+                Invalidate();
+            }
+
+        }
+    }
+
+    [Category("Appearance")]
+    [DefaultValue(typeof(SystemColors), "ControlText")]
+    public Color TextColor { get; set; }
+
+    public new ProgressBarState State
+    {
+        get => base.State;
+        set
+        {
+            if (base.State != value)
+            {
+                base.State = value;
+                Color newColor = value switch
                 {
-                    Text = value;
-                    Invalidate();
-                }
-
+                    ProgressBarState.Normal => Color.LimeGreen,
+                    ProgressBarState.Pause => Color.FromArgb(210, 200, 0),
+                    ProgressBarState.Error => Color.Red,
+                    _ => throw new ArgumentOutOfRangeException(nameof(State))
+                };
+                ForeColor = Color.FromArgb(Enabled ? 255 : 128, newColor);
             }
         }
+    }
 
-        [Category("Appearance")]
-        [DefaultValue(typeof(SystemColors), "ControlText")]
-        public Color TextColor { get; set; }
-
-        public new ProgressBarState State
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [Browsable(true)]
+    [Category("CatBehavior")]
+    [Description("ProgressBarStyleDescr")]
+    [DefaultValue(ProgressBarStyle.Blocks)]
+    public new ProgressBarStyle Style
+    {
+        get => base.Style;
+        set
         {
-            get => base.State;
-            set
+            if (base.Style == value)
             {
-                if (base.State != value)
+                return;
+            }
+            base.Style = value;
+            marqueeTimer.Interval = MarqueeAnimationSpeed;
+            marqueeTimer.Enabled = (base.Style == ProgressBarStyle.Marquee);
+        }
+    }
+
+    private void PaintMarquee(PaintEventArgs e)
+    {
+        var stepWidthPixel = (float)Width / Maximum;
+        var localValue = (int)(Value * stepWidthPixel);
+        stepWidthPixel *= Step;
+        stepWidthPixel = Math.Max(stepWidthPixel, 5);
+        var left = Math.Max(Math.Min(localValue + 2, (int)(localValue + stepWidthPixel)), 2);
+        var rec = new Rectangle(left, 2, (int)stepWidthPixel * 2, Height);
+        rec.Height -= 3;
+
+        // Create a linear gradient brush
+        using var rgBrush = new LinearGradientBrush(rec, Color.Transparent, ForeColor, 0.0f, true);
+        // Set sigma bell shape
+        rgBrush.SetSigmaBellShape(0.5f, 1.0f);
+        // Set blend triangular shape
+        rgBrush.SetBlendTriangularShape(0.5f, 1.0f);
+        // Fill rectangle again
+        e.Graphics.FillRectangle(rgBrush, rec);
+    }
+
+
+    private void AnimateTimer_OnTick(object sender, EventArgs e)
+    {
+        if (marqueeTimer.Interval != MarqueeAnimationSpeed)
+        {
+            marqueeTimer.Interval = MarqueeAnimationSpeed;
+        }
+        if (Style == ProgressBarStyle.Marquee)
+        {
+            var localValue = Value;
+            if (State != ProgressBarState.Pause)
+            {
+                localValue += Step;
+                if ((localValue >= Maximum)
+                    || (localValue < Minimum)
+                   )
                 {
-                    base.State = value;
-                    Color newColor = value switch
-                    {
-                        ProgressBarState.Normal => Color.LimeGreen,
-                        ProgressBarState.Pause => Color.FromArgb(210, 200, 0),
-                        ProgressBarState.Error => Color.Red,
-                        _ => throw new ArgumentOutOfRangeException(nameof(State))
-                    };
-                    ForeColor = Color.FromArgb(Enabled ? 255 : 128, newColor);
+                    localValue = Minimum;
                 }
+                Value = localValue;
             }
+            Refresh();
         }
 
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        [Browsable(true)]
-        [Category("CatBehavior")]
-        [Description("ProgressBarStyleDescr")]
-        [DefaultValue(ProgressBarStyle.Blocks)]
-        public new ProgressBarStyle Style
+    }
+
+    #region No Style implemented Workaround (i.e. via RDP)
+
+    /// <summary>
+    /// Taken from http://www.codeproject.com/KB/GDI-plus/ExtendedGraphics.aspx?msg=2073988#xx2073988xx
+    /// Creates the rounded rectangle path.
+    /// </summary>
+    /// <returns>The rounded rectangle path.</returns>
+    /// <param name='baseRect'> Rect.</param>
+    /// <param name="radiusX"></param>
+    /// <param name="radiusY"></param>
+    public static GraphicsPath GetRoundedRect(RectangleF baseRect, float radiusX, float radiusY)
+    {
+        var gp = new GraphicsPath();
+        gp.StartFigure();
+
+        if (radiusX <= 0.0F || radiusY <= 0.0F)
         {
-            get => base.Style;
-            set
-            {
-                if (base.Style == value)
-                {
-                    return;
-                }
-                base.Style = value;
-                marqueeTimer.Interval = MarqueeAnimationSpeed;
-                marqueeTimer.Enabled = (base.Style == ProgressBarStyle.Marquee);
-            }
+            gp.AddRectangle(baseRect);
         }
-
-        private void PaintMarquee(PaintEventArgs e)
+        else
         {
-            var stepWidthPixel = (float)Width / Maximum;
-            var localValue = (int)(Value * stepWidthPixel);
-            stepWidthPixel *= Step;
-            stepWidthPixel = Math.Max(stepWidthPixel, 5);
-            var left = Math.Max(Math.Min(localValue + 2, (int)(localValue + stepWidthPixel)), 2);
-            var rec = new Rectangle(left, 2, (int)stepWidthPixel * 2, Height);
-            rec.Height -= 3;
-
-            // Create a linear gradient brush
-            using var rgBrush = new LinearGradientBrush(rec, Color.Transparent, ForeColor, 0.0f, true);
-            // Set sigma bell shape
-            rgBrush.SetSigmaBellShape(0.5f, 1.0f);
-            // Set blend triangular shape
-            rgBrush.SetBlendTriangularShape(0.5f, 1.0f);
-            // Fill rectangle again
-            e.Graphics.FillRectangle(rgBrush, rec);
+            //arcs work with diameters (radius * 2)
+            var d = new PointF(Math.Min(radiusX * 2, baseRect.Width), Math.Min(radiusY * 2, baseRect.Height));
+            gp.AddArc(baseRect.X, baseRect.Y, d.X, d.Y, 180, 90);
+            gp.AddArc(baseRect.Right - d.X, baseRect.Y, d.X, d.Y, 270, 90);
+            gp.AddArc(baseRect.Right - d.X, baseRect.Bottom - d.Y, d.X, d.Y, 0, 90);
+            gp.AddArc(baseRect.X, baseRect.Bottom - d.Y, d.X, d.Y, 90, 90);
         }
+        gp.CloseFigure();
+        return gp;
+    }
 
+    protected void NoRendererSupport(PaintEventArgs e, Rectangle rec)
+    {
+        e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
+        e.Graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
 
-        private void AnimateTimer_OnTick(object sender, EventArgs e)
+        rec.Inflate(-1, -1);
+        DrawBackground(e.Graphics, rec);
+        DrawBackgroundShadows(e.Graphics, rec);
+        DrawBarHighlight(e.Graphics, rec);
+    }
+    private void DrawBackground(Graphics g, Rectangle rect)
+    {
+        using GraphicsPath backgroundPath = GetRoundedRect(rect, 2, 2);
+        using Brush backBrush = new SolidBrush(BackColor);
+        g.FillPath(backBrush, backgroundPath);
+    }
+    private readonly Color black30 = Color.FromArgb(30, Color.Black);
+    private readonly Color black20 = Color.FromArgb(20, Color.Black);
+    private readonly Color white128 = Color.FromArgb(128, Color.White);
+    private void DrawBarHighlight(Graphics g, Rectangle rect)
+    {
+        var tr = new Rectangle(rect.Left + 1, rect.Top + 1, rect.Width - 1, 6);
+        using (GraphicsPath tp = GetRoundedRect(tr, 2, 2))
         {
-            if (marqueeTimer.Interval != MarqueeAnimationSpeed)
+            g.SetClip(tp);
+            using (Brush tg = new LinearGradientBrush(tr, Color.WhiteSmoke, white128, LinearGradientMode.Vertical))
             {
-                marqueeTimer.Interval = MarqueeAnimationSpeed;
-            }
-            if (Style == ProgressBarStyle.Marquee)
-            {
-                var localValue = Value;
-                if (State != ProgressBarState.Pause)
-                {
-                    localValue += Step;
-                    if ((localValue >= Maximum)
-                        || (localValue < Minimum)
-                       )
-                    {
-                        localValue = Minimum;
-                    }
-                    Value = localValue;
-                }
-                Refresh();
-            }
-
-        }
-
-        #region No Style implemented Workaround (i.e. via RDP)
-
-        /// <summary>
-        /// Taken from http://www.codeproject.com/KB/GDI-plus/ExtendedGraphics.aspx?msg=2073988#xx2073988xx
-        /// Creates the rounded rectangle path.
-        /// </summary>
-        /// <returns>The rounded rectangle path.</returns>
-        /// <param name='baseRect'> Rect.</param>
-        /// <param name="radiusX"></param>
-        /// <param name="radiusY"></param>
-        public static GraphicsPath GetRoundedRect(RectangleF baseRect, float radiusX, float radiusY)
-        {
-            var gp = new GraphicsPath();
-            gp.StartFigure();
-
-            if (radiusX <= 0.0F || radiusY <= 0.0F)
-            {
-                gp.AddRectangle(baseRect);
-            }
-            else
-            {
-                //arcs work with diameters (radius * 2)
-                var d = new PointF(Math.Min(radiusX * 2, baseRect.Width), Math.Min(radiusY * 2, baseRect.Height));
-                gp.AddArc(baseRect.X, baseRect.Y, d.X, d.Y, 180, 90);
-                gp.AddArc(baseRect.Right - d.X, baseRect.Y, d.X, d.Y, 270, 90);
-                gp.AddArc(baseRect.Right - d.X, baseRect.Bottom - d.Y, d.X, d.Y, 0, 90);
-                gp.AddArc(baseRect.X, baseRect.Bottom - d.Y, d.X, d.Y, 90, 90);
-            }
-            gp.CloseFigure();
-            return gp;
-        }
-
-        protected void NoRendererSupport(PaintEventArgs e, Rectangle rec)
-        {
-            e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
-            e.Graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
-
-            rec.Inflate(-1, -1);
-            DrawBackground(e.Graphics, rec);
-            DrawBackgroundShadows(e.Graphics, rec);
-            DrawBarHighlight(e.Graphics, rec);
-        }
-        private void DrawBackground(Graphics g, Rectangle rect)
-        {
-            using GraphicsPath backgroundPath = GetRoundedRect(rect, 2, 2);
-            using Brush backBrush = new SolidBrush(BackColor);
-            g.FillPath(backBrush, backgroundPath);
-        }
-        private readonly Color black30 = Color.FromArgb(30, Color.Black);
-        private readonly Color black20 = Color.FromArgb(20, Color.Black);
-        private readonly Color white128 = Color.FromArgb(128, Color.White);
-        private void DrawBarHighlight(Graphics g, Rectangle rect)
-        {
-            var tr = new Rectangle(rect.Left + 1, rect.Top + 1, rect.Width - 1, 6);
-            using (GraphicsPath tp = GetRoundedRect(tr, 2, 2))
-            {
-                g.SetClip(tp);
-                using (Brush tg = new LinearGradientBrush(tr, Color.WhiteSmoke, white128, LinearGradientMode.Vertical))
-                {
-                    g.FillPath(tg, tp);
-                }
-                g.ResetClip();
-            }
-
-            var br = new Rectangle(rect.Left + 1, rect.Bottom - 8, rect.Width - 1, 6);
-            using GraphicsPath bp = GetRoundedRect(br, 2, 2);
-            g.SetClip(bp);
-            using (Brush bg = new LinearGradientBrush(br, Color.Transparent, black20, LinearGradientMode.Vertical))
-            {
-                g.FillPath(bg, bp);
+                g.FillPath(tg, tp);
             }
             g.ResetClip();
         }
 
-        private void DrawBackgroundShadows(Graphics g, Rectangle rect)
+        var br = new Rectangle(rect.Left + 1, rect.Bottom - 8, rect.Width - 1, 6);
+        using GraphicsPath bp = GetRoundedRect(br, 2, 2);
+        g.SetClip(bp);
+        using (Brush bg = new LinearGradientBrush(br, Color.Transparent, black20, LinearGradientMode.Vertical))
         {
-            var lr = new Rectangle(rect.Left + 2, rect.Top + 2, 10, rect.Height - 5);
-            using (Brush lg = new LinearGradientBrush(lr, black30, Color.Transparent, LinearGradientMode.Horizontal))
-            {
-                lr.X--;
-                g.FillRectangle(lg, lr);
-            }
-
-            var rr = new Rectangle(rect.Right - 12, rect.Top + 2, 10, rect.Height - 5);
-            using Brush rg = new LinearGradientBrush(rr, Color.Transparent, black20, LinearGradientMode.Horizontal);
-            g.FillRectangle(rg, rr);
+            g.FillPath(bg, bp);
         }
-        #endregion
-
-        protected override void OnPaint(PaintEventArgs e)
-        {
-            var rec = new Rectangle(0, 0, Width, Height);
-
-            if (ProgressBarRenderer.IsSupported)
-            {
-                ProgressBarRenderer.DrawHorizontalBar(e.Graphics, rec);
-            }
-            else
-            {
-                NoRendererSupport(e, rec);
-            }
-            switch (Style)
-            {
-                case ProgressBarStyle.Blocks:
-                case ProgressBarStyle.Continuous:
-                    using (var brush = new LinearGradientBrush(rec, BackColor, ForeColor,
-                                                                             LinearGradientMode.Vertical))
-                    {
-                        e.Graphics.FillRectangle(brush, 1, 1, (int)(rec.Width * ((double)Value / Maximum)) - 3, rec.Height - 3);
-                    }
-                    break;
-                case ProgressBarStyle.Marquee:
-                    PaintMarquee(e);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(Style));
-            }
-
-            using var sb = new SolidBrush(TextColor);
-            using var sf = new StringFormat(StringFormatFlags.NoWrap)
-            {
-                Alignment = TextAlignment,
-                LineAlignment = StringAlignment.Center,
-                Trimming = StringTrimming.EllipsisWord
-            };
-            rec.Inflate(-5, -2);
-            e.Graphics.DrawString(Text, Font, sb, rec, sf);
-        }
-
-
+        g.ResetClip();
     }
 
+    private void DrawBackgroundShadows(Graphics g, Rectangle rect)
+    {
+        var lr = new Rectangle(rect.Left + 2, rect.Top + 2, 10, rect.Height - 5);
+        using (Brush lg = new LinearGradientBrush(lr, black30, Color.Transparent, LinearGradientMode.Horizontal))
+        {
+            lr.X--;
+            g.FillRectangle(lg, lr);
+        }
+
+        var rr = new Rectangle(rect.Right - 12, rect.Top + 2, 10, rect.Height - 5);
+        using Brush rg = new LinearGradientBrush(rr, Color.Transparent, black20, LinearGradientMode.Horizontal);
+        g.FillRectangle(rg, rr);
+    }
+    #endregion
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        var rec = new Rectangle(0, 0, Width, Height);
+
+        if (ProgressBarRenderer.IsSupported)
+        {
+            ProgressBarRenderer.DrawHorizontalBar(e.Graphics, rec);
+        }
+        else
+        {
+            NoRendererSupport(e, rec);
+        }
+        switch (Style)
+        {
+            case ProgressBarStyle.Blocks:
+            case ProgressBarStyle.Continuous:
+                using (var brush = new LinearGradientBrush(rec, BackColor, ForeColor,
+                                                                         LinearGradientMode.Vertical))
+                {
+                    e.Graphics.FillRectangle(brush, 1, 1, (int)(rec.Width * ((double)Value / Maximum)) - 3, rec.Height - 3);
+                }
+                break;
+            case ProgressBarStyle.Marquee:
+                PaintMarquee(e);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(Style));
+        }
+
+        using var sb = new SolidBrush(TextColor);
+        using var sf = new StringFormat(StringFormatFlags.NoWrap);
+        sf.Alignment = TextAlignment;
+        sf.LineAlignment = StringAlignment.Center;
+        sf.Trimming = StringTrimming.EllipsisWord;
+        rec.Inflate(-5, -2);
+        e.Graphics.DrawString(Text, Font, sb, rec, sf);
+    }
 }
 // ReSharper restore UnusedMember.Global
 // ReSharper restore UnusedAutoPropertyAccessor.Global


### PR DESCRIPTION
- Smarter Coverage Calc override #43
- z-Parity Override fix #96
- Fix Exception thrown when drives contain symbolic / or junction directories
- Do not use WordPad anymore #102
- Some compile warnings